### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,67 @@
+# Dependencies
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build output
+dist
+
+# Development files (keep src and tsconfig for build)
+*.ts.backup
+.eslintrc.*
+.eslintignore
+
+# Testing files
+tests
+test
+*.test.*
+*.spec.*
+
+# Documentation
+README.md
+CONTRIBUTING.md
+CLAUDE.md
+TOOL_IMPROVEMENTS.md
+repositories.md
+docs
+
+# Git
+.git
+.gitignore
+.github
+
+# Environment files
+.env
+.env.local
+.env.example
+*.log
+
+# IDE and editor files
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Package manager files
+.npm
+.yarn
+pnpm-lock.yaml
+yarn.lock
+
+# Coverage reports
+coverage
+
+# Temporary files
+tmp
+temp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Build stage
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+
+FROM node:22-alpine AS production
+
+WORKDIR /app
+
+COPY package*.json ./
+
+# Install only production dependencies
+RUN npm ci --only=production && npm cache clean --force
+
+COPY --from=builder /app/dist ./dist
+
+RUN addgroup -g 1001 -S nodejs && \
+    adduser -S mcp -u 1001 -G nodejs
+
+# Change ownership of the app directory
+RUN chown -R mcp:nodejs /app
+USER mcp
+
+ENV NODE_ENV=production
+
+ENTRYPOINT ["node", "dist/index.js"]
+
+CMD [""]

--- a/README.md
+++ b/README.md
@@ -18,12 +18,53 @@ Most tools exposed by the MCP Server use stable APIs that have been available fr
 
 ## 🚀 Installation
 
-### Requirements
+### Install via Docker
+
+Build the image locally
+```bash
+docker build -t octopus-mcp-server .
+```
+
+Run with environment variables
+```bash
+docker run -i --rm -e OCTOPUS_API_KEY=your-key -e OCTOPUS_SERVER_URL=https://your-octopus.com octopus-mcp-server
+```
+
+Run with CLI arguments
+```bash
+docker run -i --rm octopus-mcp-server --server-url https://your-octopus.com --api-key YOUR_API_KEY
+```
+
+Full example configuration (for Claude Desktop, Claude Code, and Cursor):
+```json
+{
+  "mcpServers": {
+    "octopus-deploy": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "octopus-mcp-server",
+        "--server-url",
+        "https://your-octopus.com",
+        "--api-key",
+        "YOUR_API_KEY"
+      ]
+    },
+  }
+}
+```
+
+### Install via Node
+
+#### Requirements
 - Node.js >= v20.0.0
 - Octopus Deploy instance that can be accessed by the MCP server via HTTPS
 - Octopus Deploy API Key
 
-### Configuration
+#### Configuration
 
 Full example configuration (for Claude Desktop, Claude Code, and Cursor):
 ```json


### PR DESCRIPTION
Adds support for launching the MCP via Docker container with instructions added to README on how to run it.