### PR TITLE
Ensure processId is set if not provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+.idea

--- a/src/tools/getDeploymentProcess.ts
+++ b/src/tools/getDeploymentProcess.ts
@@ -24,14 +24,20 @@ This tool retrieves a deployment process by its ID. Each project has a deploymen
       readOnlyHint: true,
     },
     async ({ spaceName, processId, projectId, branchName, includeDetails = false }) => {
+
+      if (!processId && !projectId) {
+        throw new Error("Either processId or projectId must be provided.");
+      }
+
       const configuration = getClientConfigurationFromEnvironment();
       const client = await Client.create(configuration);
       const spaceId = await resolveSpaceId(client, spaceName);
       const projectRepository = projectId ? new ProjectRepository(client, spaceName) : null;
       const project = projectRepository && projectId ? await projectRepository.get(projectId) : null;
 
-      if (!processId && !projectId) {
-        throw new Error("Either processId or projectId must be provided.");
+      // If we were not supplied a processId, we assume we are retrieving the process for the specified project.
+      if (!processId) {
+        processId = project?.DeploymentProcessId;
       }
 
       if (project?.IsVersionControlled && !branchName) {


### PR DESCRIPTION
The deployment process tool currently fails to retrieve deployment processes by projectId.

This PR fixes the tool, which was failing to set the processId if one was not supplied.

Results:

<img width="749" height="182" alt="image" src="https://github.com/user-attachments/assets/ec3a5f53-06a8-4db7-aa34-38f252751529" />
