### PR TITLE
fix: Missing pagination parameters

### DIFF
--- a/src/tools/listDeployments.ts
+++ b/src/tools/listDeployments.ts
@@ -10,8 +10,8 @@ export function registerListDeploymentsTool(server: McpServer) {
     `List deployments in a space
   
   This tool lists deployments in a given space. The space name is required. When requesting latest deployment consider which deployment state the user is interested in (successful or all). Optional filters include: projects (array of project IDs), environments (array of environment IDs), tenants (array of tenant IDs), channels (array of channel IDs), taskState (one of: Canceled, Cancelling, Executing, Failed, Queued, Success, TimedOut), and take (number of results to return).`,
-    { 
-      spaceName: z.string(), 
+    {
+      spaceName: z.string(),
       projects: z.array(z.string()).optional(),
       environments: z.array(z.string()).optional(),
       tenants: z.array(z.string()).optional(),
@@ -29,7 +29,7 @@ export function registerListDeploymentsTool(server: McpServer) {
       const client = await Client.create(configuration);
       const deploymentRepository = new DeploymentRepository(client, spaceName);
 
-      const deploymentsResponse = await deploymentRepository.list({ 
+      const deploymentsResponse = await deploymentRepository.list({
         projects,
         environments,
         tenants,
@@ -38,36 +38,40 @@ export function registerListDeploymentsTool(server: McpServer) {
         skip,
         take
       });
-      
-      const deployments = deploymentsResponse.Items.map((deployment: Deployment) => ({
-        spaceId: deployment.SpaceId,
-        id: deployment.Id,
-        name: deployment.Name,
-        releaseId: deployment.ReleaseId,
-        environmentId: deployment.EnvironmentId,
-        tenantId: deployment.TenantId,
-        projectId: deployment.ProjectId,
-        channelId: deployment.ChannelId,
-        created: deployment.Created,
-        taskId: deployment.TaskId,
-        deploymentProcessId: deployment.DeploymentProcessId,
-        comments: deployment.Comments,
-        formValues: deployment.FormValues,
-        queueTime: deployment.QueueTime,
-        queueTimeExpiry: deployment.QueueTimeExpiry,
-        useGuidedFailure: deployment.UseGuidedFailure,
-        specificMachineIds: deployment.SpecificMachineIds,
-        excludedMachineIds: deployment.ExcludedMachineIds,
-        skipActions: deployment.SkipActions,
-        forcePackageDownload: deployment.ForcePackageDownload,
-        forcePackageRedeployment: deployment.ForcePackageRedeployment,
-      }));
 
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify(deployments),
+            text: JSON.stringify({
+              totalResults: deploymentsResponse.TotalResults,
+              itemsPerPage: deploymentsResponse.ItemsPerPage,
+              numberOfPages: deploymentsResponse.NumberOfPages,
+              lastPageNumber: deploymentsResponse.LastPageNumber,
+              items: deploymentsResponse.Items.map((deployment: Deployment) => ({
+                spaceId: deployment.SpaceId,
+                id: deployment.Id,
+                name: deployment.Name,
+                releaseId: deployment.ReleaseId,
+                environmentId: deployment.EnvironmentId,
+                tenantId: deployment.TenantId,
+                projectId: deployment.ProjectId,
+                channelId: deployment.ChannelId,
+                created: deployment.Created,
+                taskId: deployment.TaskId,
+                deploymentProcessId: deployment.DeploymentProcessId,
+                comments: deployment.Comments,
+                formValues: deployment.FormValues,
+                queueTime: deployment.QueueTime,
+                queueTimeExpiry: deployment.QueueTimeExpiry,
+                useGuidedFailure: deployment.UseGuidedFailure,
+                specificMachineIds: deployment.SpecificMachineIds,
+                excludedMachineIds: deployment.ExcludedMachineIds,
+                skipActions: deployment.SkipActions,
+                forcePackageDownload: deployment.ForcePackageDownload,
+                forcePackageRedeployment: deployment.ForcePackageRedeployment,
+              }))
+            }),
           },
         ],
       };

--- a/src/tools/listDeployments.ts
+++ b/src/tools/listDeployments.ts
@@ -17,13 +17,14 @@ export function registerListDeploymentsTool(server: McpServer) {
       tenants: z.array(z.string()).optional(),
       channels: z.array(z.string()).optional(),
       taskState: z.enum(["Canceled", "Cancelling", "Executing", "Failed", "Queued", "Success", "TimedOut"]).optional(),
+      skip: z.number().optional(),
       take: z.number().optional()
     },
     {
       title: "List deployments in an Octopus Deploy space",
       readOnlyHint: true,
     },
-    async ({ spaceName, projects, environments, tenants, channels, taskState, take }) => {
+    async ({ spaceName, projects, environments, tenants, channels, taskState, skip, take }) => {
       const configuration = getClientConfigurationFromEnvironment();
       const client = await Client.create(configuration);
       const deploymentRepository = new DeploymentRepository(client, spaceName);
@@ -34,6 +35,7 @@ export function registerListDeploymentsTool(server: McpServer) {
         tenants,
         channels,
         taskState: taskState ? TaskState[taskState as keyof typeof TaskState] : undefined,
+        skip,
         take
       });
       

--- a/src/tools/listProjects.ts
+++ b/src/tools/listProjects.ts
@@ -9,37 +9,47 @@ export function registerListProjectsTool(server: McpServer) {
   server.tool(
     "list_projects",
     `This tool lists all projects in a given space. ${projectsDescription} The space name is required, if you can't find the space name, ask the user directly for the name of the space. Optionally filter by partial name match using partialName parameter.`,
-    { spaceName: z.string(), partialName: z.string().optional() },
+    {
+      spaceName: z.string(), 
+      partialName: z.string().optional(),
+      skip: z.number().optional(),
+      take: z.number().optional()
+    },
     {
       title: "List all projects in an Octopus Deploy space",
       readOnlyHint: true,
     },
-    async ({ spaceName, partialName }) => {
+    async ({ spaceName, partialName, skip, take }) => {
       const configuration = getClientConfigurationFromEnvironment();
       const client = await Client.create(configuration);
       const projectRepository = new ProjectRepository(client, spaceName);
 
-      const projectsResponse = await projectRepository.list({ partialName });
-      const projects = projectsResponse.Items.map((project: Project) => ({
-        spaceId: project.SpaceId,
-        id: project.Id,
-        name: project.Name,
-        description: project.Description,
-        slug: project.Slug,
-        deploymentProcessId: project.DeploymentProcessId,
-        lifecycleId: project.LifecycleId,
-        isDisabled: project.IsDisabled,
-        repositoryUrl:
-          project.PersistenceSettings.Type === "VersionControlled"
-            ? project.PersistenceSettings.Url
-            : null,
-      }));
+      const projectsResponse = await projectRepository.list({ partialName, skip, take });
 
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify(projects),
+            text: JSON.stringify({
+              totalResults: projectsResponse.TotalResults,
+              itemsPerPage: projectsResponse.ItemsPerPage,
+              numberOfPages: projectsResponse.NumberOfPages,
+              lastPageNumber: projectsResponse.LastPageNumber,
+              items: projectsResponse.Items.map((project: Project) => ({
+                spaceId: project.SpaceId,
+                id: project.Id,
+                name: project.Name,
+                description: project.Description,
+                slug: project.Slug,
+                deploymentProcessId: project.DeploymentProcessId,
+                lifecycleId: project.LifecycleId,
+                isDisabled: project.IsDisabled,
+                repositoryUrl:
+                  project.PersistenceSettings.Type === "VersionControlled"
+                    ? project.PersistenceSettings.Url
+                    : null,
+              })),
+            }),
           },
         ],
       };

--- a/src/tools/listReleases.ts
+++ b/src/tools/listReleases.ts
@@ -12,8 +12,8 @@ export function registerListReleasesTool(server: McpServer) {
   This tool lists all releases in a given space. The space name is required. Optionally provide skip and take parameters for pagination.`,
     { 
       spaceName: z.string().describe("The space name"),
-      skip: z.number().optional().describe("Number of items to skip for pagination"),
-      take: z.number().optional().describe("Number of items to take for pagination")
+      skip: z.number().optional(),
+      take: z.number().optional()
     },
     {
       title: "List all releases in an Octopus Deploy space",

--- a/src/tools/listReleasesForProject.ts
+++ b/src/tools/listReleasesForProject.ts
@@ -13,8 +13,8 @@ export function registerListReleasesForProjectTool(server: McpServer) {
     { 
       spaceName: z.string(),
       projectId: z.string(),
-      skip: z.number().optional().describe("Number of items to skip for pagination"),
-      take: z.number().optional().describe("Number of items to take for pagination"),
+      skip: z.number().optional(),
+      take: z.number().optional(),
       searchByVersion: z.string().optional().describe("Search releases by version string")
     },
     {

--- a/src/tools/listTenants.ts
+++ b/src/tools/listTenants.ts
@@ -13,8 +13,8 @@ export function registerListTenantsTool(server: McpServer) {
   This tool lists all tenants in a given space. The space name is required. Optionally provide skip and take parameters for pagination.`,
     { 
       spaceName: z.string().describe("The space name"),
-      skip: z.number().optional().describe("Number of items to skip for pagination"),
-      take: z.number().optional().describe("Number of items to take for pagination"),
+      skip: z.number().optional(),
+      take: z.number().optional(),
       projectId: z.string().optional().describe("Filter by specific project ID"),
       tags: z.string().optional().describe("Filter by tenant tags (comma-separated list)"),
       ids: z.array(z.string()).optional().describe("Filter by specific tenant IDs"),


### PR DESCRIPTION
I went through our `list` tools and added `skip,take` parameters where they were missing (`projects` and `spaces` 😬).

Also removed explanation for these parameters as models already have a good understanding of pagination concepts so it just ate context unnecessarily.