### PR TITLE
feat: Add support for Bearer token (access token) authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Octopus Deploy Configuration for Testing
+# Copy this file to .env and fill in your actual values
+
+# Your Octopus Deploy instance URL
+OCTOPUS_SERVER_URL=https://your-octopus-instance.octopus.app
+
+# Your Octopus Deploy API key
+OCTOPUS_API_KEY=API-XXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Or use an access token (Bearer token) instead of an API key
+# OCTOPUS_ACCESS_TOKEN=your-access-token-here
+
+# Space name to use for testing (optional, defaults to "Default")
+TEST_SPACE_NAME=Default

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,11 +19,12 @@ npm start            # Run compiled server from dist/
 
 ### Testing the Server
 ```bash
-# Test with environment variables
+# Credentials must be supplied via environment variables (they are not accepted as CLI flags
+# to avoid exposure in the host process list).
 OCTOPUS_API_KEY=API-KEY OCTOPUS_SERVER_URL=https://your-octopus.com npm start
 
-# Test with command line arguments
-npm start -- --server-url https://your-octopus.com --api-key YOUR_API_KEY
+# Server URL may also be supplied via the --server-url flag:
+OCTOPUS_API_KEY=API-KEY npm start -- --server-url https://your-octopus.com
 ```
 
 ## Architecture
@@ -47,10 +48,12 @@ Each tool file exports a registration that includes:
 
 ### Client Configuration
 The server accepts configuration via:
-1. Environment variables: `OCTOPUS_API_KEY`, `OCTOPUS_SERVER_URL`
-2. CLI arguments: `--api-key`, `--server-url`
+1. Credentials (env vars only): `OCTOPUS_API_KEY` or `OCTOPUS_ACCESS_TOKEN`
+2. Server URL: `OCTOPUS_SERVER_URL` env var or `--server-url` CLI flag
 3. Toolset filtering: `--toolsets` to enable specific tool groups
 4. Version checking: `--list-tools-by-version` to see tool compatibility
+
+Credentials are deliberately not accepted as CLI flags — they would be visible to any local user via `ps aux` / `/proc/<pid>/cmdline`.
 
 ## TypeScript Style Guide
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,10 @@ Most tools exposed by the MCP Server use stable APIs that have been available fr
 
 ### Install via Docker
 
-Run with environment variables
+Credentials must be supplied via environment variables to avoid exposing them in the host process list (`ps aux` / `/proc/<pid>/cmdline`). The Octopus server URL can still be supplied via the `--server-url` flag.
+
 ```bash
 docker run -i --rm -e OCTOPUS_API_KEY=your-key -e OCTOPUS_SERVER_URL=https://your-octopus.com octopusdeploy/mcp-server
-```
-
-Run with CLI arguments
-```bash
-docker run -i --rm octopusdeploy/mcp-server --server-url https://your-octopus.com --api-key YOUR_API_KEY
 ```
 
 Full example configuration (for Claude Desktop, Claude Code, and Cursor):
@@ -41,12 +37,16 @@ Full example configuration (for Claude Desktop, Claude Code, and Cursor):
         "run",
         "-i",
         "--rm",
-        "octopusdeploy/mcp-server",
-        "--server-url",
-        "https://your-octopus.com",
-        "--api-key",
-        "YOUR_API_KEY"
-      ]
+        "-e",
+        "OCTOPUS_SERVER_URL",
+        "-e",
+        "OCTOPUS_API_KEY",
+        "octopusdeploy/mcp-server"
+      ],
+      "env": {
+        "OCTOPUS_SERVER_URL": "https://your-octopus.com",
+        "OCTOPUS_API_KEY": "YOUR_API_KEY"
+      }
     },
   }
 }
@@ -78,7 +78,11 @@ Full example configuration (for Claude Desktop, Claude Code, and Cursor):
     "octopusdeploy": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@octopusdeploy/mcp-server", "--api-key", "YOUR_API_KEY", "--server-url", "https://your-octopus.com"]
+      "args": ["-y", "@octopusdeploy/mcp-server"],
+      "env": {
+        "OCTOPUS_SERVER_URL": "https://your-octopus.com",
+        "OCTOPUS_API_KEY": "YOUR_API_KEY"
+      }
     }
   }
 }
@@ -91,47 +95,44 @@ Full example configuration (for Claude Desktop, Claude Code, and Cursor):
     "octopusdeploy": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@octopusdeploy/mcp-server", "--api-key", "YOUR_API_KEY", "--server-url", "https://your-octopus.com", "--no-read-only"]
+      "args": ["-y", "@octopusdeploy/mcp-server", "--no-read-only"],
+      "env": {
+        "OCTOPUS_SERVER_URL": "https://your-octopus.com",
+        "OCTOPUS_API_KEY": "YOUR_API_KEY"
+      }
     }
   }
 }
 ```
 
-The Octopus MCP Server is typically configured within your AI Client of choice. 
+The Octopus MCP Server is typically configured within your AI Client of choice.
 
-It is packaged as an npm package and executed via Node's `npx` command. Your configuration will include the command invocation `npx`, and a set of arguments that supply the Octopus MCP Server package and provide the Octopus Server URL and API key required, if they are not available as environment variables.
-
-The command line invocation you will be configuring will be one of the two following variants:
+It is packaged as an npm package and executed via Node's `npx` command. Credentials (API key or access token) must be supplied via environment variables — they are not accepted as command-line arguments to avoid exposing secrets in the process list. The Octopus server URL may be supplied via either the `OCTOPUS_SERVER_URL` environment variable or the `--server-url` flag.
 
 ```bash
+OCTOPUS_API_KEY=API-KEY \
+OCTOPUS_SERVER_URL=https://your-octopus.com \
 npx -y @octopusdeploy/mcp-server
 ```
 
-With configuration provided via environment variables:
+Or with the server URL on the command line:
 ```bash
-OCTOPUS_API_KEY=API-KEY
-OCTOPUS_SERVER_URL=https://your-octopus.com
-```
-
-Or with configuration supplied via the command line:
-```bash
-npx -y @octopusdeploy/mcp-server --server-url https://your-octopus.com --api-key YOUR_API_KEY
+OCTOPUS_API_KEY=API-KEY \
+npx -y @octopusdeploy/mcp-server --server-url https://your-octopus.com
 ```
 
 ### Authentication
 
-The MCP server supports two authentication methods:
+The MCP server supports two authentication methods. Both are supplied via environment variables — credentials are not accepted on the command line because flags are visible in the host process list to any local user.
 
 #### API Key (recommended for interactive use)
 
 API keys are the standard authentication method for Octopus Deploy. You can generate one from your Octopus Deploy user profile.
 
 ```bash
-# Via environment variable
-OCTOPUS_API_KEY=API-XXXXXXXXXXXXXXXXXXXXXXXXXX
-
-# Via command line argument
-npx -y @octopusdeploy/mcp-server --api-key YOUR_API_KEY --server-url https://your-octopus.com
+OCTOPUS_API_KEY=API-XXXXXXXXXXXXXXXXXXXXXXXXXX \
+OCTOPUS_SERVER_URL=https://your-octopus.com \
+npx -y @octopusdeploy/mcp-server
 ```
 
 #### Access Token / Bearer Token (automated scenarios only)
@@ -139,11 +140,9 @@ npx -y @octopusdeploy/mcp-server --api-key YOUR_API_KEY --server-url https://you
 The server also supports short-lived access tokens (Bearer tokens) as an alternative to API keys. This authentication method is intended **only for automated scenarios** where an external system issues a short-lived token to the MCP server (e.g., CI/CD pipelines, automated orchestration, or machine-to-machine workflows). Do not use long-lived Bearer tokens — use API keys instead for interactive or long-running sessions.
 
 ```bash
-# Via environment variable
-OCTOPUS_ACCESS_TOKEN=your-short-lived-token
-
-# Via command line argument
-npx -y @octopusdeploy/mcp-server --access-token YOUR_TOKEN --server-url https://your-octopus.com
+OCTOPUS_ACCESS_TOKEN=your-short-lived-token \
+OCTOPUS_SERVER_URL=https://your-octopus.com \
+npx -y @octopusdeploy/mcp-server
 ```
 
 Full example configuration with an access token:
@@ -153,13 +152,17 @@ Full example configuration with an access token:
     "octopusdeploy": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@octopusdeploy/mcp-server", "--access-token", "YOUR_TOKEN", "--server-url", "https://your-octopus.com"]
+      "args": ["-y", "@octopusdeploy/mcp-server"],
+      "env": {
+        "OCTOPUS_SERVER_URL": "https://your-octopus.com",
+        "OCTOPUS_ACCESS_TOKEN": "YOUR_TOKEN"
+      }
     }
   }
 }
 ```
 
-If both an API key and an access token are provided, the access token takes precedence.
+If both an API key and an access token are provided, the access token takes precedence. The active authentication method is recorded in the log file (configurable with `--log-file`) so operators can confirm which credential is in use.
 
 ### Configuration Options
 
@@ -214,15 +217,17 @@ npx -y @octopusdeploy/mcp-server --no-read-only
 
 #### Complete Examples
 
+All examples below assume `OCTOPUS_API_KEY` is set in the environment. The `--server-url` flag is shown for clarity but can also be provided via `OCTOPUS_SERVER_URL`.
+
 ```bash
 # Development setup with only core and project tools
-npx -y @octopusdeploy/mcp-server --toolsets core,projects --server-url https://your-octopus.com --api-key YOUR_API_KEY
+npx -y @octopusdeploy/mcp-server --toolsets core,projects --server-url https://your-octopus.com
 
 # Full production setup with all tools (read-only by default)
-npx -y @octopusdeploy/mcp-server --toolsets all --server-url https://your-octopus.com --api-key YOUR_API_KEY
+npx -y @octopusdeploy/mcp-server --toolsets all --server-url https://your-octopus.com
 
 # Development setup with write operations enabled
-npx -y @octopusdeploy/mcp-server --no-read-only --server-url https://your-octopus.com --api-key YOUR_API_KEY
+npx -y @octopusdeploy/mcp-server --no-read-only --server-url https://your-octopus.com
 ```
 
 #### Other command line arguments

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ We are planning to release a native ARM build shortly so that those arguments wi
 #### Requirements
 - Node.js >= v20.0.0
 - Octopus Deploy instance that can be accessed by the MCP server via HTTPS
-- Octopus Deploy API Key
+- Octopus Deploy API Key or Access Token (see [Authentication](#authentication) below)
 
 #### Configuration
 
@@ -117,6 +117,49 @@ Or with configuration supplied via the command line:
 ```bash
 npx -y @octopusdeploy/mcp-server --server-url https://your-octopus.com --api-key YOUR_API_KEY
 ```
+
+### Authentication
+
+The MCP server supports two authentication methods:
+
+#### API Key (recommended for interactive use)
+
+API keys are the standard authentication method for Octopus Deploy. You can generate one from your Octopus Deploy user profile.
+
+```bash
+# Via environment variable
+OCTOPUS_API_KEY=API-XXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Via command line argument
+npx -y @octopusdeploy/mcp-server --api-key YOUR_API_KEY --server-url https://your-octopus.com
+```
+
+#### Access Token / Bearer Token (automated scenarios only)
+
+The server also supports short-lived access tokens (Bearer tokens) as an alternative to API keys. This authentication method is intended **only for automated scenarios** where an external system issues a short-lived token to the MCP server (e.g., CI/CD pipelines, automated orchestration, or machine-to-machine workflows). Do not use long-lived Bearer tokens — use API keys instead for interactive or long-running sessions.
+
+```bash
+# Via environment variable
+OCTOPUS_ACCESS_TOKEN=your-short-lived-token
+
+# Via command line argument
+npx -y @octopusdeploy/mcp-server --access-token YOUR_TOKEN --server-url https://your-octopus.com
+```
+
+Full example configuration with an access token:
+```json
+{
+  "mcpServers": {
+    "octopusdeploy": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@octopusdeploy/mcp-server", "--access-token", "YOUR_TOKEN", "--server-url", "https://your-octopus.com"]
+    }
+  }
+}
+```
+
+If both an API key and an access token are provided, the access token takes precedence.
 
 ### Configuration Options
 

--- a/src/helpers/__tests__/getClientConfiguration.test.ts
+++ b/src/helpers/__tests__/getClientConfiguration.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { getClientConfiguration } from "../getClientConfigurationFromEnvironment.js";
+
+describe("getClientConfiguration", () => {
+  describe("validation", () => {
+    it("throws when instanceURL is missing", () => {
+      expect(() =>
+        getClientConfiguration({ apiKey: "API-KEY" }),
+      ).toThrowError(/Octopus server URL must be provided/);
+    });
+
+    it("throws when instanceURL is an empty string", () => {
+      expect(() =>
+        getClientConfiguration({ instanceURL: "", apiKey: "API-KEY" }),
+      ).toThrowError(/Octopus server URL must be provided/);
+    });
+
+    it("throws when instanceURL is whitespace only", () => {
+      expect(() =>
+        getClientConfiguration({ instanceURL: "   ", apiKey: "API-KEY" }),
+      ).toThrowError(/Octopus server URL must be provided/);
+    });
+
+    it("throws when both apiKey and accessToken are missing", () => {
+      expect(() =>
+        getClientConfiguration({ instanceURL: "https://octopus.example.com" }),
+      ).toThrowError(/OCTOPUS_API_KEY or OCTOPUS_ACCESS_TOKEN/);
+    });
+
+    it("throws when both credentials are empty strings", () => {
+      expect(() =>
+        getClientConfiguration({
+          instanceURL: "https://octopus.example.com",
+          apiKey: "",
+          accessToken: "",
+        }),
+      ).toThrowError(/OCTOPUS_API_KEY or OCTOPUS_ACCESS_TOKEN/);
+    });
+
+    it("throws when both credentials are whitespace only", () => {
+      expect(() =>
+        getClientConfiguration({
+          instanceURL: "https://octopus.example.com",
+          apiKey: "   ",
+          accessToken: "\t\n",
+        }),
+      ).toThrowError(/OCTOPUS_API_KEY or OCTOPUS_ACCESS_TOKEN/);
+    });
+  });
+
+  describe("API key auth", () => {
+    it("returns config with apiKey when only apiKey provided", () => {
+      const config = getClientConfiguration({
+        instanceURL: "https://octopus.example.com",
+        apiKey: "API-XXXX",
+      });
+
+      expect(config.instanceURL).toBe("https://octopus.example.com");
+      expect(config.apiKey).toBe("API-XXXX");
+      expect(config.accessToken).toBeUndefined();
+    });
+
+    it("returns config with apiKey when accessToken is empty", () => {
+      const config = getClientConfiguration({
+        instanceURL: "https://octopus.example.com",
+        apiKey: "API-XXXX",
+        accessToken: "",
+      });
+
+      expect(config.apiKey).toBe("API-XXXX");
+      expect(config.accessToken).toBeUndefined();
+    });
+  });
+
+  describe("access token auth", () => {
+    it("returns config with accessToken when only accessToken provided", () => {
+      const config = getClientConfiguration({
+        instanceURL: "https://octopus.example.com",
+        accessToken: "Bearer-Token-Value",
+      });
+
+      expect(config.instanceURL).toBe("https://octopus.example.com");
+      expect(config.accessToken).toBe("Bearer-Token-Value");
+      expect(config.apiKey).toBeUndefined();
+    });
+
+    it("returns config with accessToken when apiKey is empty", () => {
+      const config = getClientConfiguration({
+        instanceURL: "https://octopus.example.com",
+        apiKey: "",
+        accessToken: "Bearer-Token-Value",
+      });
+
+      expect(config.accessToken).toBe("Bearer-Token-Value");
+      expect(config.apiKey).toBeUndefined();
+    });
+  });
+
+  describe("precedence", () => {
+    it("uses access token over API key when both are provided", () => {
+      const config = getClientConfiguration({
+        instanceURL: "https://octopus.example.com",
+        apiKey: "API-XXXX",
+        accessToken: "Bearer-Token-Value",
+      });
+
+      expect(config.accessToken).toBe("Bearer-Token-Value");
+      expect(config.apiKey).toBeUndefined();
+    });
+  });
+
+  describe("user agent", () => {
+    it("sets userAgentApp on the returned config", () => {
+      const config = getClientConfiguration({
+        instanceURL: "https://octopus.example.com",
+        apiKey: "API-XXXX",
+      });
+
+      expect(config.userAgentApp).toMatch(/^octopus-mcp-server\//);
+    });
+  });
+});

--- a/src/helpers/errorHandling.ts
+++ b/src/helpers/errorHandling.ts
@@ -58,7 +58,7 @@ export function handleOctopusApiError(
     isErrorWithMessage(error, "provide a valid API key")
   ) {
     throw new Error(
-      "Authentication failed. Ensure OCTOPUS_API_KEY environment variable is set with a valid API key. " +
+      "Authentication failed. Ensure a valid API key (OCTOPUS_API_KEY) or access token (OCTOPUS_ACCESS_TOKEN) is provided. " +
         "You can generate an API key from your Octopus Deploy user profile.",
     );
   }

--- a/src/helpers/getClientConfigurationFromEnvironment.ts
+++ b/src/helpers/getClientConfigurationFromEnvironment.ts
@@ -8,6 +8,7 @@ const USER_AGENT_NAME = "octopus-mcp-server";
 export interface ConfigurationOptions {
   instanceURL?: string;
   apiKey?: string;
+  accessToken?: string;
 }
 
 function isEmpty(value: string | undefined): value is undefined | "" {
@@ -22,13 +23,30 @@ function constructUserAgent(): string {
 }
 
 function getClientConfiguration(options: ConfigurationOptions = {}): ClientConfiguration {
-  if (isEmpty(options.instanceURL) || isEmpty(options.apiKey)) {
+  const hasApiKey = !isEmpty(options.apiKey);
+  const hasAccessToken = !isEmpty(options.accessToken);
+
+  if (isEmpty(options.instanceURL)) {
     throw new Error(
-      "Octopus server URL and API key must be provided either via command line arguments (--server-url, --api-key) or environment variables (OCTOPUS_SERVER_URL, OCTOPUS_API_KEY)."
+      "Octopus server URL must be provided either via command line argument (--server-url) or environment variable (OCTOPUS_SERVER_URL)."
+    );
+  }
+
+  if (!hasApiKey && !hasAccessToken) {
+    throw new Error(
+      "Octopus authentication must be provided. Supply either an API key (--api-key or OCTOPUS_API_KEY) or an access token (--access-token or OCTOPUS_ACCESS_TOKEN)."
     );
   }
 
   const userAgent = constructUserAgent();
+
+  if (hasAccessToken) {
+    return {
+      userAgentApp: userAgent,
+      instanceURL: options.instanceURL,
+      accessToken: options.accessToken,
+    };
+  }
 
   return {
     userAgentApp: userAgent,
@@ -41,5 +59,6 @@ export function getClientConfigurationFromEnvironment(): ClientConfiguration {
   return getClientConfiguration({
     instanceURL: env["CLI_SERVER_URL"] || env["OCTOPUS_SERVER_URL"],
     apiKey: env["CLI_API_KEY"] || env["OCTOPUS_API_KEY"],
+    accessToken: env["CLI_ACCESS_TOKEN"] || env["OCTOPUS_ACCESS_TOKEN"],
   });
 }

--- a/src/helpers/getClientConfigurationFromEnvironment.ts
+++ b/src/helpers/getClientConfigurationFromEnvironment.ts
@@ -2,6 +2,7 @@ import { type ClientConfiguration } from "@octopusdeploy/api-client";
 import { env } from "process";
 import { SEMVER_VERSION } from "../utils/version.js";
 import { getClientInfo } from "../utils/clientInfo.js";
+import { logger } from "../utils/logger.js";
 
 const USER_AGENT_NAME = "octopus-mcp-server";
 
@@ -22,7 +23,7 @@ function constructUserAgent(): string {
   return userAgent;
 }
 
-function getClientConfiguration(options: ConfigurationOptions = {}): ClientConfiguration {
+export function getClientConfiguration(options: ConfigurationOptions = {}): ClientConfiguration {
   const hasApiKey = !isEmpty(options.apiKey);
   const hasAccessToken = !isEmpty(options.accessToken);
 
@@ -34,13 +35,14 @@ function getClientConfiguration(options: ConfigurationOptions = {}): ClientConfi
 
   if (!hasApiKey && !hasAccessToken) {
     throw new Error(
-      "Octopus authentication must be provided. Supply either an API key (--api-key or OCTOPUS_API_KEY) or an access token (--access-token or OCTOPUS_ACCESS_TOKEN)."
+      "Octopus authentication must be provided via OCTOPUS_API_KEY or OCTOPUS_ACCESS_TOKEN environment variable."
     );
   }
 
   const userAgent = constructUserAgent();
 
   if (hasAccessToken) {
+    logger.info("Authenticating with access token (Bearer)");
     return {
       userAgentApp: userAgent,
       instanceURL: options.instanceURL,
@@ -48,6 +50,7 @@ function getClientConfiguration(options: ConfigurationOptions = {}): ClientConfi
     };
   }
 
+  logger.info("Authenticating with API key");
   return {
     userAgentApp: userAgent,
     instanceURL: options.instanceURL,
@@ -58,7 +61,7 @@ function getClientConfiguration(options: ConfigurationOptions = {}): ClientConfi
 export function getClientConfigurationFromEnvironment(): ClientConfiguration {
   return getClientConfiguration({
     instanceURL: env["CLI_SERVER_URL"] || env["OCTOPUS_SERVER_URL"],
-    apiKey: env["CLI_API_KEY"] || env["OCTOPUS_API_KEY"],
-    accessToken: env["CLI_ACCESS_TOKEN"] || env["OCTOPUS_ACCESS_TOKEN"],
+    apiKey: env["OCTOPUS_API_KEY"],
+    accessToken: env["OCTOPUS_ACCESS_TOKEN"],
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ program
   .version(SEMVER_VERSION)
   .option("-s, --server-url <url>", "Octopus server URL")
   .option("-k, --api-key <key>", "Octopus API key")
+  .option("-t, --access-token <token>", "Octopus access token (Bearer token)")
   .option(
     "--toolsets <toolsets>",
     `Comma-separated list of toolsets to enable, or "all" (default: all). Available toolsets: ${DEFAULT_TOOLSETS.join(", ")}`,
@@ -89,6 +90,9 @@ if (options.serverUrl) {
 }
 if (options.apiKey) {
   process.env.CLI_API_KEY = options.apiKey;
+}
+if (options.accessToken) {
+  process.env.CLI_ACCESS_TOKEN = options.accessToken;
 }
 
 // Set up initialization callback to capture client info

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,6 @@ program
   .description("Octopus Deploy MCP Server")
   .version(SEMVER_VERSION)
   .option("-s, --server-url <url>", "Octopus server URL")
-  .option("-k, --api-key <key>", "Octopus API key")
-  .option("-t, --access-token <token>", "Octopus access token (Bearer token)")
   .option(
     "--toolsets <toolsets>",
     `Comma-separated list of toolsets to enable, or "all" (default: all). Available toolsets: ${DEFAULT_TOOLSETS.join(", ")}`,
@@ -87,12 +85,6 @@ logger.setQuietMode(options.quiet);
 
 if (options.serverUrl) {
   process.env.CLI_SERVER_URL = options.serverUrl;
-}
-if (options.apiKey) {
-  process.env.CLI_API_KEY = options.apiKey;
-}
-if (options.accessToken) {
-  process.env.CLI_ACCESS_TOKEN = options.accessToken;
 }
 
 // Set up initialization callback to capture client info

--- a/src/tools/__tests__/testSetup.ts
+++ b/src/tools/__tests__/testSetup.ts
@@ -1,4 +1,4 @@
-import { beforeAll, expect } from "vitest";
+import { expect } from "vitest";
 import { config } from "dotenv";
 
 // Load environment variables from .env files
@@ -6,8 +6,8 @@ config();
 
 export const testConfig = {
   octopusServerUrl: process.env.OCTOPUS_SERVER_URL || process.env.CLI_SERVER_URL,
-  octopusApiKey: process.env.OCTOPUS_API_KEY || process.env.CLI_API_KEY,
-  octopusAccessToken: process.env.OCTOPUS_ACCESS_TOKEN || process.env.CLI_ACCESS_TOKEN,
+  octopusApiKey: process.env.OCTOPUS_API_KEY,
+  octopusAccessToken: process.env.OCTOPUS_ACCESS_TOKEN,
   testSpaceName: process.env.TEST_SPACE_NAME || "Default",
   timeout: 30000, // 30 seconds
 };
@@ -20,7 +20,7 @@ export function validateTestEnvironment(): void {
   }
 
   if (!testConfig.octopusApiKey && !testConfig.octopusAccessToken) {
-    missing.push("OCTOPUS_API_KEY (or CLI_API_KEY) or OCTOPUS_ACCESS_TOKEN (or CLI_ACCESS_TOKEN)");
+    missing.push("OCTOPUS_API_KEY or OCTOPUS_ACCESS_TOKEN");
   }
 
   if (missing.length > 0) {
@@ -59,7 +59,3 @@ export function parseToolResponse(response: any): any {
   assertToolResponse(response);
   return JSON.parse(response.content[0].text);
 }
-
-beforeAll(() => {
-  validateTestEnvironment();
-});

--- a/src/tools/__tests__/testSetup.ts
+++ b/src/tools/__tests__/testSetup.ts
@@ -7,6 +7,7 @@ config();
 export const testConfig = {
   octopusServerUrl: process.env.OCTOPUS_SERVER_URL || process.env.CLI_SERVER_URL,
   octopusApiKey: process.env.OCTOPUS_API_KEY || process.env.CLI_API_KEY,
+  octopusAccessToken: process.env.OCTOPUS_ACCESS_TOKEN || process.env.CLI_ACCESS_TOKEN,
   testSpaceName: process.env.TEST_SPACE_NAME || "Default",
   timeout: 30000, // 30 seconds
 };
@@ -18,8 +19,8 @@ export function validateTestEnvironment(): void {
     missing.push("OCTOPUS_SERVER_URL (or CLI_SERVER_URL)");
   }
 
-  if (!testConfig.octopusApiKey) {
-    missing.push("OCTOPUS_API_KEY (or CLI_API_KEY)");
+  if (!testConfig.octopusApiKey && !testConfig.octopusAccessToken) {
+    missing.push("OCTOPUS_API_KEY (or CLI_API_KEY) or OCTOPUS_ACCESS_TOKEN (or CLI_ACCESS_TOKEN)");
   }
 
   if (missing.length > 0) {


### PR DESCRIPTION
## Summary
- Adds support for short-lived access tokens (Bearer tokens) as an alternative to API key authentication
- New CLI option `--access-token` / `-t` and environment variable `OCTOPUS_ACCESS_TOKEN`
- Access token takes precedence when both credentials are provided
- The `@octopusdeploy/api-client` SDK already supports this via the `accessToken` property on `ClientConfiguration`

**Note:** Bearer token auth is intended only for automated scenarios (CI/CD pipelines, orchestration, machine-to-machine workflows) where the issued token is short-lived.

### Files changed
- `src/helpers/getClientConfigurationFromEnvironment.ts` — Core auth logic supporting both credential types
- `src/index.ts` — New `--access-token` CLI option
- `src/helpers/errorHandling.ts` — Updated auth error messages
- `src/tools/__tests__/testSetup.ts` — Test config supports access tokens
- `README.md` — New Authentication section documenting both methods
- `.env.example` — Documents `OCTOPUS_ACCESS_TOKEN`

## Test plan
- [ ] `npm run build` compiles cleanly
- [ ] Start server with `--access-token` flag and verify it connects
- [ ] Set `OCTOPUS_ACCESS_TOKEN` env var and verify it connects
- [ ] Provide neither API key nor access token — verify clear error message
- [ ] Provide both — verify access token is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)