### PR TITLE
fix: Add version control reference to release and deployment data

### DIFF
--- a/src/tools/createRelease.ts
+++ b/src/tools/createRelease.ts
@@ -105,6 +105,14 @@ This tool creates a new release for a project. The space name and project name a
 
         const response = await releaseRepository.create(command);
 
+        let versionControlReference: { GitRef?: string; GitCommit?: string } | undefined;
+        try {
+          const release = await releaseRepository.get(response.ReleaseId);
+          versionControlReference = release.VersionControlReference;
+        } catch {
+          versionControlReference = undefined;
+        }
+
         return {
           content: [
             {
@@ -114,6 +122,7 @@ This tool creates a new release for a project. The space name and project name a
                   success: true,
                   releaseId: response.ReleaseId,
                   releaseVersion: response.ReleaseVersion,
+                  versionControlReference,
                   message: `Release ${response.ReleaseVersion} created successfully`,
                   helpText:
                     "Use find_releases to view release details, or use deploy_release to deploy this release to environments.",

--- a/src/tools/findReleases.ts
+++ b/src/tools/findReleases.ts
@@ -51,6 +51,7 @@ export function registerFindReleasesTool(server: McpServer) {
                   ignoreChannelRules: release.IgnoreChannelRules,
                   selectedPackages: release.SelectedPackages,
                   selectedGitResources: release.SelectedGitResources,
+                  versionControlReference: release.VersionControlReference,
                   buildInformation: release.BuildInformation,
                   customFields: release.CustomFields
                 }),
@@ -89,6 +90,7 @@ export function registerFindReleasesTool(server: McpServer) {
                 ignoreChannelRules: release.IgnoreChannelRules,
                 selectedPackages: release.SelectedPackages,
                 selectedGitResources: release.SelectedGitResources,
+                versionControlReference: release.VersionControlReference,
                 buildInformation: release.BuildInformation,
                 customFields: release.CustomFields
               }))

--- a/src/tools/getDeploymentFromUrl.ts
+++ b/src/tools/getDeploymentFromUrl.ts
@@ -53,13 +53,16 @@ export async function getDeploymentFromUrl(client: Client, params: GetDeployment
   }
 
   let releaseVersion: string | undefined;
+  let versionControlReference: { GitRef?: string; GitCommit?: string } | undefined;
   if (deployment.ReleaseId) {
     const releaseRepository = new ReleaseRepository(client, spaceName);
     try {
       const release = await releaseRepository.get(deployment.ReleaseId);
       releaseVersion = release.Version;
+      versionControlReference = release.VersionControlReference;
     } catch {
       releaseVersion = undefined;
+      versionControlReference = undefined;
     }
   }
 
@@ -83,6 +86,7 @@ export async function getDeploymentFromUrl(client: Client, params: GetDeployment
       name: deployment.Name,
       releaseId: deployment.ReleaseId,
       releaseVersion,
+      versionControlReference,
       environmentId: deployment.EnvironmentId,
       tenantId: deployment.TenantId,
       projectId: deployment.ProjectId,

--- a/src/tools/listDeployments.ts
+++ b/src/tools/listDeployments.ts
@@ -50,6 +50,7 @@ export function registerListDeploymentsTool(server: McpServer) {
       );
 
       const releaseVersions = new Map<string, string>();
+      const releaseVersionControlReferences = new Map<string, { GitRef?: string; GitCommit?: string }>();
 
       if (releaseIds.length > 0) {
         const releaseRepository = new ReleaseRepository(client, spaceName);
@@ -58,6 +59,9 @@ export function registerListDeploymentsTool(server: McpServer) {
         releaseResults.forEach((result, index) => {
           if (result.status === "fulfilled") {
             releaseVersions.set(releaseIds[index]!, result.value.Version);
+            if (result.value.VersionControlReference) {
+              releaseVersionControlReferences.set(releaseIds[index]!, result.value.VersionControlReference);
+            }
           }
         });
       }
@@ -73,6 +77,7 @@ export function registerListDeploymentsTool(server: McpServer) {
               lastPageNumber: deploymentsResponse.LastPageNumber,
               items: deployments.map((deployment) => {
                 const releaseVersion = deployment.ReleaseId ? releaseVersions.get(deployment.ReleaseId) : undefined;
+                const versionControlReference = deployment.ReleaseId ? releaseVersionControlReferences.get(deployment.ReleaseId) : undefined;
                 const publicUrl = releaseVersion
                   ? getPublicUrl(
                       `${configuration.instanceURL}/app#/{spaceId}/projects/{projectId}/deployments/releases/{releaseVersion}/deployments/{deploymentId}`,
@@ -91,6 +96,7 @@ export function registerListDeploymentsTool(server: McpServer) {
                   name: deployment.Name,
                   releaseId: deployment.ReleaseId,
                   releaseVersion,
+                  versionControlReference,
                   environmentId: deployment.EnvironmentId,
                   tenantId: deployment.TenantId,
                   projectId: deployment.ProjectId,

--- a/src/tools/listReleasesForProject.ts
+++ b/src/tools/listReleasesForProject.ts
@@ -51,6 +51,7 @@ export function registerListReleasesForProjectTool(server: McpServer) {
                 ignoreChannelRules: release.IgnoreChannelRules,
                 selectedPackages: release.SelectedPackages,
                 selectedGitResources: release.SelectedGitResources,
+                versionControlReference: release.VersionControlReference,
                 buildInformation: release.BuildInformation,
                 customFields: release.CustomFields
               }))


### PR DESCRIPTION
## Summary
This PR adds support for exposing version control reference information (Git ref and commit) across release and deployment-related tools. This allows users to see the Git commit and branch information associated with releases and their deployments.

## Key Changes
- **createRelease.ts**: Fetch and return `VersionControlReference` after creating a release
- **findReleases.ts**: Include `VersionControlReference` in release search results (both single and paginated responses)
- **listReleasesForProject.ts**: Include `VersionControlReference` in project release listings
- **listDeployments.ts**: Fetch and include `VersionControlReference` for each deployment's associated release
- **getDeploymentFromUrl.ts**: Fetch and include `VersionControlReference` when retrieving deployment details from a URL

## Implementation Details
- The `VersionControlReference` object contains optional `GitRef` and `GitCommit` fields
- Version control references are fetched from the release repository when needed
- Error handling is implemented to gracefully handle cases where version control reference data is unavailable
- The change maintains backward compatibility by making the field optional in all responses

https://claude.ai/code/session_01QVuT9BagXbuu1uT9YpZqpX