### PR TITLE
refactor: Migrate tools to registerTool with full MCP annotations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,13 +53,15 @@ Each tool file exports a registration that includes:
 New tools must use `server.registerTool(name, config, handler)`:
 
 ```typescript
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
+
 server.registerTool(
   "find_releases",
   {
     title: "Find releases",
     description: "...",
     inputSchema: refinedZodSchema, // accepts ZodRawShapeCompat OR a full zod schema with refinements
-    annotations: { readOnlyHint: true },
+    annotations: READ_ONLY_TOOL_ANNOTATIONS,
   },
   async (args) => { /* ... */ },
 );
@@ -68,6 +70,16 @@ server.registerTool(
 Use `superRefine` (or a discriminated union) to encode cross-field invariants — mutually exclusive arguments, required-when-other-present rules, etc. — so the SDK rejects bad combinations during input validation and the LLM gets a structured error rather than a silent override at runtime. Constraints expressed only in description prose are not enforced.
 
 When migrating existing tools from `tool()` to `registerTool()`: the description and annotations move into the config object as named fields (`description`, `annotations`); the input schema becomes `inputSchema`. The handler signature is unchanged.
+
+##### Annotation constants
+
+All four MCP `ToolAnnotations` hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) should be set explicitly so well-behaved clients can derive correct UI affordances (auto-approve, confirm-before-run, etc.) instead of falling back to worst-case defaults. To keep these consistent across tools, use the constants in [`src/types/toolAnnotations.ts`](src/types/toolAnnotations.ts):
+
+- `READ_ONLY_TOOL_ANNOTATIONS` — every read/list/find/get tool, plus `read_resource` and `grep_task_log`.
+- `ADDITIVE_WRITE_TOOL_ANNOTATIONS` — write tools whose effect is purely additive (create a new record, no overwrite). Example: `create_release`.
+- `DESTRUCTIVE_WRITE_TOOL_ANNOTATIONS` — write tools that may overwrite or otherwise mutate live state. Example: `deploy_release`.
+
+All three set `openWorldHint: false` because the server is bound to a single configured Octopus instance with a fixed entity schema — that's a closed world, not an open one (the SDK contrasts "web search" / open with "memory tool" / closed). Don't hand-roll an inline annotations object; reach for one of the constants and add a new profile to `toolAnnotations.ts` if a genuinely new shape appears.
 
 #### Write gating: use `requireConfirmation`
 

--- a/src/tools/createRelease.ts
+++ b/src/tools/createRelease.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { ADDITIVE_WRITE_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { handleOctopusApiError } from "../helpers/errorHandling.js";
 import {
   requireConfirmation,
@@ -10,68 +11,68 @@ import {
 } from "../helpers/requireConfirmation.js";
 
 export function registerCreateReleaseTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "create_release",
-    `Create a new release for an Octopus Deploy project
-
-This tool creates a new release for a project. The space name and project name are required. All other parameters are optional and will use Octopus defaults if not specified.`,
-    {
-      spaceName: z.string().describe("The space name"),
-      projectName: z.string().describe("The project name"),
-      releaseVersion: z
-        .string()
-        .optional()
-        .describe(
-          "The version for the release (e.g., '1.0.0'). If not specified, Octopus will auto-generate based on project settings.",
-        ),
-      channelName: z
-        .string()
-        .optional()
-        .describe("The channel name (uses default channel if not specified)"),
-      packageVersion: z
-        .string()
-        .optional()
-        .describe("Default package version to use for all packages"),
-      packages: z
-        .array(z.string())
-        .optional()
-        .describe(
-          "Array of package specifications (format depends on Octopus configuration)",
-        ),
-      gitCommit: z.string().optional().describe("Git commit hash"),
-      gitRef: z.string().optional().describe("Git reference (branch or tag)"),
-      releaseNotes: z
-        .string()
-        .optional()
-        .describe("Release notes for this release"),
-      ignoreIfAlreadyExists: z
-        .boolean()
-        .optional()
-        .describe(
-          "If true, skip creation if release already exists (returns existing release)",
-        ),
-      ignoreChannelRules: z
-        .boolean()
-        .optional()
-        .describe("If true, ignore channel version rules"),
-      packagePrerelease: z
-        .string()
-        .optional()
-        .describe("Package prerelease tag"),
-      customFields: z
-        .record(z.string())
-        .optional()
-        .describe("Custom field values as key-value pairs"),
-      confirm: z
-        .boolean()
-        .optional()
-        .describe(
-          "Required only when the MCP client does not support elicitation. Set to true to confirm release creation; otherwise the tool aborts.",
-        ),
-    },
     {
       title: "Create a new release in Octopus Deploy",
-      readOnlyHint: false,
+      description: `Create a new release for an Octopus Deploy project
+
+This tool creates a new release for a project. The space name and project name are required. All other parameters are optional and will use Octopus defaults if not specified.`,
+      inputSchema: {
+        spaceName: z.string().describe("The space name"),
+        projectName: z.string().describe("The project name"),
+        releaseVersion: z
+          .string()
+          .optional()
+          .describe(
+            "The version for the release (e.g., '1.0.0'). If not specified, Octopus will auto-generate based on project settings.",
+          ),
+        channelName: z
+          .string()
+          .optional()
+          .describe("The channel name (uses default channel if not specified)"),
+        packageVersion: z
+          .string()
+          .optional()
+          .describe("Default package version to use for all packages"),
+        packages: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Array of package specifications (format depends on Octopus configuration)",
+          ),
+        gitCommit: z.string().optional().describe("Git commit hash"),
+        gitRef: z.string().optional().describe("Git reference (branch or tag)"),
+        releaseNotes: z
+          .string()
+          .optional()
+          .describe("Release notes for this release"),
+        ignoreIfAlreadyExists: z
+          .boolean()
+          .optional()
+          .describe(
+            "If true, skip creation if release already exists (returns existing release)",
+          ),
+        ignoreChannelRules: z
+          .boolean()
+          .optional()
+          .describe("If true, ignore channel version rules"),
+        packagePrerelease: z
+          .string()
+          .optional()
+          .describe("Package prerelease tag"),
+        customFields: z
+          .record(z.string())
+          .optional()
+          .describe("Custom field values as key-value pairs"),
+        confirm: z
+          .boolean()
+          .optional()
+          .describe(
+            "Required only when the MCP client does not support elicitation. Set to true to confirm release creation; otherwise the tool aborts.",
+          ),
+      },
+      annotations: ADDITIVE_WRITE_TOOL_ANNOTATIONS,
     },
     async ({
       spaceName,

--- a/src/tools/deployRelease.ts
+++ b/src/tools/deployRelease.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { DESTRUCTIVE_WRITE_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { handleOctopusApiError } from "../helpers/errorHandling.js";
 import {
   requireConfirmation,
@@ -10,96 +11,96 @@ import {
 } from "../helpers/requireConfirmation.js";
 
 export function registerDeployReleaseTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "deploy_release",
-    `Deploy a release to one or more environments in Octopus Deploy
+    {
+      title: "Deploy a release to environments in Octopus Deploy",
+      description: `Deploy a release to one or more environments in Octopus Deploy
 
 This tool supports both tenanted and untenanted deployments:
 - **Untenanted**: Don't provide tenants or tenantTags. Can deploy to multiple environments at once.
 - **Tenanted**: Provide tenants or tenantTags. Can only deploy to ONE environment, but can target multiple tenants.
 
 The tool automatically determines which deployment type to use based on the parameters provided.`,
-    {
-      spaceName: z.string().describe("The space name"),
-      projectName: z.string().describe("The project name"),
-      releaseVersion: z
-        .string()
-        .describe("The release version to deploy (e.g., '1.0.0')"),
-      environmentNames: z
-        .array(z.string())
-        .describe(
-          "Array of environment names. For tenanted deployments, must contain exactly one environment.",
-        ),
-      tenants: z
-        .array(z.string())
-        .optional()
-        .describe("Array of tenant names for tenanted deployment (optional)"),
-      tenantTags: z
-        .array(z.string())
-        .optional()
-        .describe(
-          "Array of tenant tags for tenanted deployment (e.g., ['Region/US-West', 'Tier/Production'])",
-        ),
-      forcePackageRedeployment: z
-        .boolean()
-        .optional()
-        .describe("Force redeployment of packages"),
-      updateVariableSnapshot: z
-        .boolean()
-        .optional()
-        .describe("Update the variable snapshot"),
-      forcePackageDownload: z
-        .boolean()
-        .optional()
-        .describe("Force package download"),
-      specificMachineNames: z
-        .array(z.string())
-        .optional()
-        .describe("Deploy to specific machines only"),
-      excludedMachineNames: z
-        .array(z.string())
-        .optional()
-        .describe("Exclude specific machines from deployment"),
-      skipStepNames: z
-        .array(z.string())
-        .optional()
-        .describe("Skip specific deployment steps"),
-      useGuidedFailure: z
-        .boolean()
-        .optional()
-        .describe("Use guided failure mode"),
-      runAt: z
-        .string()
-        .optional()
-        .describe("Schedule deployment for later (ISO 8601 date string)"),
-      noRunAfter: z
-        .string()
-        .optional()
-        .describe(
-          "Don't run deployment after this time (ISO 8601 date string)",
-        ),
-      variables: z
-        .record(z.string())
-        .optional()
-        .describe("Prompted variable values as key-value pairs"),
-      deploymentFreezeOverrideReason: z
-        .string()
-        .optional()
-        .describe("Reason for overriding deployment freeze"),
-      deploymentFreezeNames: z
-        .array(z.string())
-        .optional()
-        .describe("Names of deployment freezes to override"),
-      confirm: z
-        .boolean()
-        .optional()
-        .describe(
-          "Required only when the MCP client does not support elicitation. Set to true to confirm deployment; otherwise the tool aborts.",
-        ),
-    },
-    {
-      title: "Deploy a release to environments in Octopus Deploy",
-      readOnlyHint: false,
+      inputSchema: {
+        spaceName: z.string().describe("The space name"),
+        projectName: z.string().describe("The project name"),
+        releaseVersion: z
+          .string()
+          .describe("The release version to deploy (e.g., '1.0.0')"),
+        environmentNames: z
+          .array(z.string())
+          .describe(
+            "Array of environment names. For tenanted deployments, must contain exactly one environment.",
+          ),
+        tenants: z
+          .array(z.string())
+          .optional()
+          .describe("Array of tenant names for tenanted deployment (optional)"),
+        tenantTags: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Array of tenant tags for tenanted deployment (e.g., ['Region/US-West', 'Tier/Production'])",
+          ),
+        forcePackageRedeployment: z
+          .boolean()
+          .optional()
+          .describe("Force redeployment of packages"),
+        updateVariableSnapshot: z
+          .boolean()
+          .optional()
+          .describe("Update the variable snapshot"),
+        forcePackageDownload: z
+          .boolean()
+          .optional()
+          .describe("Force package download"),
+        specificMachineNames: z
+          .array(z.string())
+          .optional()
+          .describe("Deploy to specific machines only"),
+        excludedMachineNames: z
+          .array(z.string())
+          .optional()
+          .describe("Exclude specific machines from deployment"),
+        skipStepNames: z
+          .array(z.string())
+          .optional()
+          .describe("Skip specific deployment steps"),
+        useGuidedFailure: z
+          .boolean()
+          .optional()
+          .describe("Use guided failure mode"),
+        runAt: z
+          .string()
+          .optional()
+          .describe("Schedule deployment for later (ISO 8601 date string)"),
+        noRunAfter: z
+          .string()
+          .optional()
+          .describe(
+            "Don't run deployment after this time (ISO 8601 date string)",
+          ),
+        variables: z
+          .record(z.string())
+          .optional()
+          .describe("Prompted variable values as key-value pairs"),
+        deploymentFreezeOverrideReason: z
+          .string()
+          .optional()
+          .describe("Reason for overriding deployment freeze"),
+        deploymentFreezeNames: z
+          .array(z.string())
+          .optional()
+          .describe("Names of deployment freezes to override"),
+        confirm: z
+          .boolean()
+          .optional()
+          .describe(
+            "Required only when the MCP client does not support elicitation. Set to true to confirm deployment; otherwise the tool aborts.",
+          ),
+      },
+      annotations: DESTRUCTIVE_WRITE_TOOL_ANNOTATIONS,
     },
     async ({
       spaceName,

--- a/src/tools/findAccounts.ts
+++ b/src/tools/findAccounts.ts
@@ -2,6 +2,7 @@ import { Client, resolveSpaceId, type ResourceCollection } from "@octopusdeploy/
 import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import {
   type AccountResource,
@@ -11,27 +12,27 @@ import {
 import { validateEntityId, handleOctopusApiError, ENTITY_PREFIXES } from "../helpers/errorHandling.js";
 
 export function registerFindAccountsTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "find_accounts",
-    `Find accounts in a space - can retrieve a single account by ID or list all accounts
+    {
+      title: "Find accounts in an Octopus Deploy space",
+      description: `Find accounts in a space - can retrieve a single account by ID or list all accounts
 
 This unified tool can either:
 - Get detailed information about a specific account when accountId is provided
 - List all accounts in a space when accountId is omitted
 
 You can optionally filter by various parameters like name, account type, etc. when listing.`,
-    {
-      spaceName: z.string(),
-      accountId: z.string().optional().describe("The ID of a specific account to retrieve. If omitted, lists all accounts."),
-      skip: z.number().optional().describe("Number of accounts to skip for pagination (only used when listing)"),
-      take: z.number().optional().describe("Number of accounts to take for pagination (only used when listing)"),
-      ids: z.array(z.string()).optional().describe("Filter by specific account IDs (only used when listing)"),
-      partialName: z.string().optional().describe("Filter by partial name match (only used when listing)"),
-      accountType: z.nativeEnum(AccountType).optional().describe("Filter by account type (only used when listing)"),
-    },
-    {
-      title: "Find accounts in an Octopus Deploy space",
-      readOnlyHint: true,
+      inputSchema: {
+        spaceName: z.string(),
+        accountId: z.string().optional().describe("The ID of a specific account to retrieve. If omitted, lists all accounts."),
+        skip: z.number().optional().describe("Number of accounts to skip for pagination (only used when listing)"),
+        take: z.number().optional().describe("Number of accounts to take for pagination (only used when listing)"),
+        ids: z.array(z.string()).optional().describe("Filter by specific account IDs (only used when listing)"),
+        partialName: z.string().optional().describe("Filter by partial name match (only used when listing)"),
+        accountType: z.nativeEnum(AccountType).optional().describe("Filter by account type (only used when listing)"),
+      },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async ({
       spaceName,

--- a/src/tools/findCertificates.ts
+++ b/src/tools/findCertificates.ts
@@ -2,36 +2,37 @@ import { Client, resolveSpaceId, type ResourceCollection } from "@octopusdeploy/
 import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { type CertificateResource, mapCertificateResource } from "../types/certificateTypes.js";
 import { validateEntityId, handleOctopusApiError, ENTITY_PREFIXES } from "../helpers/errorHandling.js";
 
 export function registerFindCertificatesTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "find_certificates",
-    `Find certificates in a space - can retrieve a single certificate by ID or list all certificates
+    {
+      title: "Find certificates in an Octopus Deploy space",
+      description: `Find certificates in a space - can retrieve a single certificate by ID or list all certificates
 
 This unified tool can either:
 - Get detailed information about a specific certificate when certificateId is provided
 - List all certificates in a space when certificateId is omitted
 
 You can optionally filter by various parameters like name, archived status, tenant, etc. when listing.`,
-    {
-      spaceName: z.string(),
-      certificateId: z.string().optional().describe("The ID of a specific certificate to retrieve. If omitted, lists all certificates."),
-      skip: z.number().optional().describe("Number of certificates to skip for pagination (only used when listing)"),
-      take: z.number().optional().describe("Number of certificates to take for pagination (only used when listing)"),
-      search: z.string().optional().describe("Search term to filter certificates (only used when listing)"),
-      archived: z.boolean().optional().describe("Filter by archived status (only used when listing)"),
-      tenant: z.string().optional().describe("Filter by tenant (only used when listing)"),
-      firstResult: z.number().optional().describe("Index of first result to return (only used when listing)"),
-      orderBy: z.string().optional().describe("Field to order results by (only used when listing)"),
-      ids: z.array(z.string()).optional().describe("Filter by specific certificate IDs (only used when listing)"),
-      partialName: z.string().optional().describe("Filter by partial name match (only used when listing)"),
-    },
-    {
-      title: "Find certificates in an Octopus Deploy space",
-      readOnlyHint: true,
+      inputSchema: {
+        spaceName: z.string(),
+        certificateId: z.string().optional().describe("The ID of a specific certificate to retrieve. If omitted, lists all certificates."),
+        skip: z.number().optional().describe("Number of certificates to skip for pagination (only used when listing)"),
+        take: z.number().optional().describe("Number of certificates to take for pagination (only used when listing)"),
+        search: z.string().optional().describe("Search term to filter certificates (only used when listing)"),
+        archived: z.boolean().optional().describe("Filter by archived status (only used when listing)"),
+        tenant: z.string().optional().describe("Filter by tenant (only used when listing)"),
+        firstResult: z.number().optional().describe("Index of first result to return (only used when listing)"),
+        orderBy: z.string().optional().describe("Field to order results by (only used when listing)"),
+        ids: z.array(z.string()).optional().describe("Filter by specific certificate IDs (only used when listing)"),
+        partialName: z.string().optional().describe("Filter by partial name match (only used when listing)"),
+      },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async ({
       spaceName,

--- a/src/tools/findDeploymentTargets.ts
+++ b/src/tools/findDeploymentTargets.ts
@@ -2,43 +2,44 @@ import { Client, resolveSpaceId, type ResourceCollection } from "@octopusdeploy/
 import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { type DeploymentTargetResource } from "../types/deploymentTargetTypes.js";
 import { validateEntityId, handleOctopusApiError, ENTITY_PREFIXES } from "../helpers/errorHandling.js";
 
 export function registerFindDeploymentTargetsTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "find_deployment_targets",
-    `Find deployment targets (machines) in a space - can retrieve a single target by ID or list all targets
+    {
+      title: "Find deployment targets in an Octopus Deploy space",
+      description: `Find deployment targets (machines) in a space - can retrieve a single target by ID or list all targets
 
 This unified tool can either:
 - Get detailed information about a specific deployment target when targetId is provided
 - List all deployment targets in a space when targetId is omitted
 
 You can optionally filter by various parameters like name, roles, health status, etc. when listing.`,
-    {
-      spaceName: z.string(),
-      targetId: z.string().optional().describe("The ID of a specific deployment target to retrieve. If omitted, lists all deployment targets."),
-      skip: z.number().optional().describe("Number of targets to skip for pagination (only used when listing)"),
-      take: z.number().optional().describe("Number of targets to take for pagination (only used when listing)"),
-      name: z.string().optional().describe("Filter by exact name (only used when listing)"),
-      ids: z.array(z.string()).optional().describe("Filter by specific target IDs (only used when listing)"),
-      partialName: z.string().optional().describe("Filter by partial name match (only used when listing)"),
-      roles: z.array(z.string()).optional().describe("A list of roles / target tags to filter by (only used when listing)"),
-      isDisabled: z.boolean().optional().describe("Filter by disabled status (only used when listing)"),
-      healthStatuses: z.array(z.string()).optional().describe("Possible values: Healthy, Unhealthy, Unavailable, Unknown, HasWarnings (only used when listing)"),
-      commStyles: z.array(z.string()).optional().describe("Filter by communication styles (only used when listing)"),
-      tenantIds: z.array(z.string()).optional().describe("Filter by tenant IDs (only used when listing)"),
-      tenantTags: z.array(z.string()).optional().describe("Filter by tenant tags (only used when listing)"),
-      environmentIds: z.array(z.string()).optional().describe("Filter by environment IDs (only used when listing)"),
-      thumbprint: z.string().optional().describe("Filter by thumbprint (only used when listing)"),
-      deploymentId: z.string().optional().describe("Filter by deployment ID (only used when listing)"),
-      shellNames: z.array(z.string()).optional().describe("Filter by shell names (only used when listing)"),
-      deploymentTargetTypes: z.array(z.string()).optional().describe("Filter by deployment target types (only used when listing)"),
-    },
-    {
-      title: "Find deployment targets in an Octopus Deploy space",
-      readOnlyHint: true,
+      inputSchema: {
+        spaceName: z.string(),
+        targetId: z.string().optional().describe("The ID of a specific deployment target to retrieve. If omitted, lists all deployment targets."),
+        skip: z.number().optional().describe("Number of targets to skip for pagination (only used when listing)"),
+        take: z.number().optional().describe("Number of targets to take for pagination (only used when listing)"),
+        name: z.string().optional().describe("Filter by exact name (only used when listing)"),
+        ids: z.array(z.string()).optional().describe("Filter by specific target IDs (only used when listing)"),
+        partialName: z.string().optional().describe("Filter by partial name match (only used when listing)"),
+        roles: z.array(z.string()).optional().describe("A list of roles / target tags to filter by (only used when listing)"),
+        isDisabled: z.boolean().optional().describe("Filter by disabled status (only used when listing)"),
+        healthStatuses: z.array(z.string()).optional().describe("Possible values: Healthy, Unhealthy, Unavailable, Unknown, HasWarnings (only used when listing)"),
+        commStyles: z.array(z.string()).optional().describe("Filter by communication styles (only used when listing)"),
+        tenantIds: z.array(z.string()).optional().describe("Filter by tenant IDs (only used when listing)"),
+        tenantTags: z.array(z.string()).optional().describe("Filter by tenant tags (only used when listing)"),
+        environmentIds: z.array(z.string()).optional().describe("Filter by environment IDs (only used when listing)"),
+        thumbprint: z.string().optional().describe("Filter by thumbprint (only used when listing)"),
+        deploymentId: z.string().optional().describe("Filter by deployment ID (only used when listing)"),
+        shellNames: z.array(z.string()).optional().describe("Filter by shell names (only used when listing)"),
+        deploymentTargetTypes: z.array(z.string()).optional().describe("Filter by deployment target types (only used when listing)"),
+      },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async ({
       spaceName,

--- a/src/tools/findReleases.ts
+++ b/src/tools/findReleases.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import {
   validateEntityId,
   handleOctopusApiError,
@@ -96,7 +97,7 @@ export function registerFindReleasesTool(server: McpServer) {
   Each summary includes a resourceUri for fetching the full release body
   (release notes, packages, build information, custom fields).`,
       inputSchema: findReleasesSchema,
-      annotations: { readOnlyHint: true },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async ({ spaceName, releaseId, projectId, searchByVersion, skip, take }) => {
       const client = await Client.create(getClientConfigurationFromEnvironment());

--- a/src/tools/findTenants.ts
+++ b/src/tools/findTenants.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { getPublicUrl } from "../helpers/getPublicUrl.js";
 import type { TenantResource } from "../types/tenantsTypes.js";
 import { tenantsDescription } from "../types/tenantsTypes.js";
@@ -126,9 +127,11 @@ export async function findTenantsHandler(params: FindTenantsParams) {
 }
 
 export function registerFindTenantsTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "find_tenants",
-    `Find tenants in a space - can retrieve a single tenant by ID or list all tenants
+    {
+      title: "Find tenants in an Octopus Deploy space",
+      description: `Find tenants in a space - can retrieve a single tenant by ID or list all tenants
 
   This unified tool can either:
   - Get details for a specific tenant when tenantId is provided, including the projects and environments the tenant is associated with
@@ -137,31 +140,29 @@ export function registerFindTenantsTool(server: McpServer) {
   ${tenantsDescription}
 
   Optionally provide filtering and pagination parameters when listing.`,
-    {
-      spaceName: z.string().describe("The space name"),
-      tenantId: z.string().optional().describe("The ID of a specific tenant to retrieve. If omitted, lists all tenants."),
-      skip: z.number().optional().describe("Number of tenants to skip for pagination (only used when listing)"),
-      take: z.number().optional().describe("Number of tenants to take for pagination (only used when listing)"),
-      projectId: z
-        .string()
-        .optional()
-        .describe("Filter by specific project ID (only used when listing)"),
-      tags: z
-        .string()
-        .optional()
-        .describe("Filter by tenant tags (comma-separated list, only used when listing)"),
-      ids: z
-        .array(z.string())
-        .optional()
-        .describe("Filter by specific tenant IDs (only used when listing)"),
-      partialName: z
-        .string()
-        .optional()
-        .describe("Filter by partial tenant name match (only used when listing)"),
-    },
-    {
-      title: "Find tenants in an Octopus Deploy space",
-      readOnlyHint: true,
+      inputSchema: {
+        spaceName: z.string().describe("The space name"),
+        tenantId: z.string().optional().describe("The ID of a specific tenant to retrieve. If omitted, lists all tenants."),
+        skip: z.number().optional().describe("Number of tenants to skip for pagination (only used when listing)"),
+        take: z.number().optional().describe("Number of tenants to take for pagination (only used when listing)"),
+        projectId: z
+          .string()
+          .optional()
+          .describe("Filter by specific project ID (only used when listing)"),
+        tags: z
+          .string()
+          .optional()
+          .describe("Filter by tenant tags (comma-separated list, only used when listing)"),
+        ids: z
+          .array(z.string())
+          .optional()
+          .describe("Filter by specific tenant IDs (only used when listing)"),
+        partialName: z
+          .string()
+          .optional()
+          .describe("Filter by partial tenant name match (only used when listing)"),
+      },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     findTenantsHandler,
   );

--- a/src/tools/getBranches.ts
+++ b/src/tools/getBranches.ts
@@ -2,26 +2,27 @@ import { Client, resolveSpaceId } from "@octopusdeploy/api-client";
 import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { getProjectBranches } from "../helpers/vcsProjectHelpers.js";
 import { validateEntityId, handleOctopusApiError, ENTITY_PREFIXES } from "../helpers/errorHandling.js";
 
 export function registerGetBranchesTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "get_branches",
-    `Get Git branches for a version-controlled project
-
-This tool retrieves Git branches for a specific project in a space. The space name and project ID are required. Optionally provide searchByName, skip, and take parameters for filtering and pagination.`,
-    {
-      spaceName: z.string(),
-      projectId: z.string(),
-      searchByName: z.string().optional(),
-      skip: z.number().optional(),
-      take: z.number().optional(),
-    },
     {
       title: "Get Git branches for a version-controlled project",
-      readOnlyHint: true,
+      description: `Get Git branches for a version-controlled project
+
+This tool retrieves Git branches for a specific project in a space. The space name and project ID are required. Optionally provide searchByName, skip, and take parameters for filtering and pagination.`,
+      inputSchema: {
+        spaceName: z.string(),
+        projectId: z.string(),
+        searchByName: z.string().optional(),
+        skip: z.number().optional(),
+        take: z.number().optional(),
+      },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async ({ spaceName, projectId, searchByName, skip, take }) => {
       validateEntityId(projectId, 'project', ENTITY_PREFIXES.project);

--- a/src/tools/getCurrentUser.ts
+++ b/src/tools/getCurrentUser.ts
@@ -1,6 +1,7 @@
 import { Client } from "@octopusdeploy/api-client";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { handleOctopusApiError } from "../helpers/errorHandling.js";
 
@@ -16,15 +17,15 @@ interface CurrentUser {
 }
 
 export function registerGetCurrentUserTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "get_current_user",
-    `Get information about the current authenticated user
-
-This tool retrieves information about the currently authenticated user from the Octopus Deploy API.`,
-    {},
     {
       title: "Get current user information",
-      readOnlyHint: true,
+      description: `Get information about the current authenticated user
+
+This tool retrieves information about the currently authenticated user from the Octopus Deploy API.`,
+      inputSchema: {},
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async () => {
       try {

--- a/src/tools/getDeploymentFromUrl.ts
+++ b/src/tools/getDeploymentFromUrl.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { getClientConfigurationFromEnvironment } from '../helpers/getClientConfigurationFromEnvironment.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerToolDefinition } from '../types/toolConfig.js';
+import { READ_ONLY_TOOL_ANNOTATIONS } from '../types/toolAnnotations.js';
 import { parseOctopusUrl, extractDeploymentId } from '../helpers/urlParser.js';
 import { resolveSpaceNameFromId } from '../helpers/spaceResolver.js';
 import { getPublicUrl } from '../helpers/getPublicUrl.js';
@@ -129,9 +130,11 @@ export async function getDeploymentFromUrl(client: Client, params: GetDeployment
 }
 
 export function registerGetDeploymentFromUrlTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     'get_deployment_from_url',
-    `Get deployment details from an Octopus Deploy deployment URL. Returns comprehensive deployment information including the task ID needed to view execution logs.
+    {
+      title: 'Get deployment details from an Octopus Deploy URL',
+      description: `Get deployment details from an Octopus Deploy deployment URL. Returns comprehensive deployment information including the task ID needed to view execution logs.
 
 Accepts deployment URLs like:
 https://your-octopus.com/app#/Spaces-1/projects/my-app/deployments/releases/1.0.0/deployments/Deployments-123
@@ -150,13 +153,11 @@ Recommended workflow for investigating deployment issues:
 3b. Call grep_task_log with the taskId to search the raw log for a specific error / pattern
 
 Handles space ID to space name resolution automatically.`,
-    {
-      url: z.string()
-        .describe("Full Octopus Deploy deployment URL (e.g., https://your-octopus.com/app#/Spaces-1/projects/my-app/deployments/releases/1.0.0/deployments/Deployments-123)")
-    },
-    {
-      title: 'Get deployment details from an Octopus Deploy URL',
-      readOnlyHint: true,
+      inputSchema: {
+        url: z.string()
+          .describe("Full Octopus Deploy deployment URL (e.g., https://your-octopus.com/app#/Spaces-1/projects/my-app/deployments/releases/1.0.0/deployments/Deployments-123)")
+      },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async (args) => {
       const { url } = args as GetDeploymentFromUrlParams;

--- a/src/tools/getDeploymentProcess.ts
+++ b/src/tools/getDeploymentProcess.ts
@@ -6,47 +6,48 @@ import {
 import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { type DeploymentProcessResource } from "../types/deploymentProcessTypes.js";
 import { getProjectBranches } from "../helpers/vcsProjectHelpers.js";
 
 export function registerGetDeploymentProcessTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "get_deployment_process",
-    `Get deployment process by ID
-
-This tool retrieves a deployment process by its ID. Each project has a deployment process attached, and releases/deployments can also have frozen processes attached.`,
-    {
-      spaceName: z.string(),
-      projectId: z
-        .string()
-        .optional()
-        .describe(
-          "The ID of the project to retrieve the deployment process for. If processId is not provided, this parameter is required.",
-        ),
-      processId: z
-        .string()
-        .optional()
-        .describe(
-          "The ID of the deployment process to retrieve. If not provided, the deployment process for the project will be retrieved.",
-        ),
-      branchName: z
-        .string()
-        .optional()
-        .describe(
-          "Optional branch name to get the deployment process for a specific branch (if using version controlled projects). Try `main` or `master` if unsure.",
-        ),
-      includeDetails: z
-        .boolean()
-        .optional()
-        .default(false)
-        .describe(
-          "Include detailed properties for steps and actions. Defaults to false.",
-        ),
-    },
     {
       title: "Get deployment process details from Octopus Deploy",
-      readOnlyHint: true,
+      description: `Get deployment process by ID
+
+This tool retrieves a deployment process by its ID. Each project has a deployment process attached, and releases/deployments can also have frozen processes attached.`,
+      inputSchema: {
+        spaceName: z.string(),
+        projectId: z
+          .string()
+          .optional()
+          .describe(
+            "The ID of the project to retrieve the deployment process for. If processId is not provided, this parameter is required.",
+          ),
+        processId: z
+          .string()
+          .optional()
+          .describe(
+            "The ID of the deployment process to retrieve. If not provided, the deployment process for the project will be retrieved.",
+          ),
+        branchName: z
+          .string()
+          .optional()
+          .describe(
+            "Optional branch name to get the deployment process for a specific branch (if using version controlled projects). Try `main` or `master` if unsure.",
+          ),
+        includeDetails: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "Include detailed properties for steps and actions. Defaults to false.",
+          ),
+      },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async ({
       spaceName,

--- a/src/tools/getKubernetesLiveStatus.ts
+++ b/src/tools/getKubernetesLiveStatus.ts
@@ -3,24 +3,25 @@ import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { validateEntityId, handleOctopusApiError, ENTITY_PREFIXES, isErrorWithMessage } from "../helpers/errorHandling.js";
 
 export function registerGetKubernetesLiveStatusTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "get_kubernetes_live_status",
-    `Get Kubernetes live status for a project and environment
-  
-  This tool retrieves the live status of Kubernetes resources for a specific project and environment. Optionally include a tenant ID for multi-tenant deployments.`,
-    { 
-      spaceName: z.string().describe("The space name"),
-      projectId: z.string().describe("The ID of the project"),
-      environmentId: z.string().describe("The ID of the environment"),
-      tenantId: z.string().optional().describe("The ID of the tenant (for multi-tenant deployments)"),
-      summaryOnly: z.boolean().optional().describe("Return summary information only")
-    },
     {
       title: "Get Kubernetes live status from Octopus Deploy",
-      readOnlyHint: true,
+      description: `Get Kubernetes live status for a project and environment
+
+  This tool retrieves the live status of Kubernetes resources for a specific project and environment. Optionally include a tenant ID for multi-tenant deployments.`,
+      inputSchema: {
+        spaceName: z.string().describe("The space name"),
+        projectId: z.string().describe("The ID of the project"),
+        environmentId: z.string().describe("The ID of the environment"),
+        tenantId: z.string().optional().describe("The ID of the tenant (for multi-tenant deployments)"),
+        summaryOnly: z.boolean().optional().describe("Return summary information only")
+      },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async ({ spaceName, projectId, environmentId, tenantId, summaryOnly = false }) => {
       validateEntityId(projectId, 'project', ENTITY_PREFIXES.project);

--- a/src/tools/getMissingTenantVariables.ts
+++ b/src/tools/getMissingTenantVariables.ts
@@ -3,24 +3,25 @@ import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { validateEntityId, handleOctopusApiError, ENTITY_PREFIXES } from "../helpers/errorHandling.js";
 
 export function registerGetMissingTenantVariablesTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "get_missing_tenant_variables",
-    `Get missing tenant variables
-  
-  This tool retrieves tenant variables that are missing values. Optionally filter by tenant, project, or environment.`,
-    { 
-      spaceName: z.string().describe("The space name"),
-      tenantId: z.string().optional().describe("Filter by specific tenant ID"),
-      projectId: z.string().optional().describe("Filter by specific project ID"),
-      environmentId: z.string().optional().describe("Filter by specific environment ID"),
-      includeDetails: z.boolean().optional().describe("Include detailed information about missing variables")
-    },
     {
       title: "Get missing tenant variables from Octopus Deploy",
-      readOnlyHint: true,
+      description: `Get missing tenant variables
+
+  This tool retrieves tenant variables that are missing values. Optionally filter by tenant, project, or environment.`,
+      inputSchema: {
+        spaceName: z.string().describe("The space name"),
+        tenantId: z.string().optional().describe("Filter by specific tenant ID"),
+        projectId: z.string().optional().describe("Filter by specific project ID"),
+        environmentId: z.string().optional().describe("Filter by specific environment ID"),
+        includeDetails: z.boolean().optional().describe("Include detailed information about missing variables")
+      },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async ({ spaceName, tenantId, projectId, environmentId, includeDetails = false }) => {
       if (tenantId) {

--- a/src/tools/getTaskFromUrl.ts
+++ b/src/tools/getTaskFromUrl.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { getClientConfigurationFromEnvironment } from '../helpers/getClientConfigurationFromEnvironment.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerToolDefinition } from '../types/toolConfig.js';
+import { READ_ONLY_TOOL_ANNOTATIONS } from '../types/toolAnnotations.js';
 import { tasksDescription } from '../types/taskTypes.js';
 import { parseOctopusUrl, extractTaskId } from '../helpers/urlParser.js';
 import { resolveSpaceNameFromId } from '../helpers/spaceResolver.js';
@@ -57,9 +58,11 @@ export async function getTaskFromUrl(client: Client, params: GetTaskFromUrlParam
 }
 
 export function registerGetTaskFromUrlTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     'get_task_from_url',
-    `Get task details from an Octopus Deploy task URL. Returns full task details including execution logs and state.
+    {
+      title: 'Get task details from an Octopus Deploy URL',
+      description: `Get task details from an Octopus Deploy task URL. Returns full task details including execution logs and state.
 
 Accepts task URLs like:
 https://your-octopus.com/app#/Spaces-1/tasks/ServerTasks-456
@@ -75,13 +78,11 @@ If you have a deployment URL, use this workflow:
 2. Use the returned taskResourceUri (structured tree) or call grep_task_log with the returned taskId to search the raw log
 
 ${tasksDescription}`,
-    {
-      url: z.string()
-        .describe("Full Octopus Deploy task URL containing a task ID (e.g., https://your-octopus.com/app#/Spaces-1/tasks/ServerTasks-456)")
-    },
-    {
-      title: 'Get task details from an Octopus Deploy URL',
-      readOnlyHint: true,
+      inputSchema: {
+        url: z.string()
+          .describe("Full Octopus Deploy task URL containing a task ID (e.g., https://your-octopus.com/app#/Spaces-1/tasks/ServerTasks-456)")
+      },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async (args) => {
       const { url } = args as GetTaskFromUrlParams;

--- a/src/tools/getTenantVariables.ts
+++ b/src/tools/getTenantVariables.ts
@@ -3,26 +3,27 @@ import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { validateEntityId, handleOctopusApiError, ENTITY_PREFIXES } from "../helpers/errorHandling.js";
 
 export function registerGetTenantVariablesTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "get_tenant_variables",
-    `Get tenant variables by type
-  
+    {
+      title: "Get tenant variables from Octopus Deploy",
+      description: `Get tenant variables by type
+
   This tool retrieves different types of tenant variables. Use variableType parameter to specify which type:
   - "all": Get all tenant variables
   - "common": Get common variables only
   - "project": Get project-specific variables only`,
-    { 
-      spaceName: z.string().describe("The space name"),
-      tenantId: z.string().describe("The ID of the tenant to retrieve variables for"),
-      variableType: z.enum(["all", "common", "project"]).describe("Type of variables to retrieve"),
-      includeMissingVariables: z.boolean().optional().describe("Include missing variables in the response (for common/project types)")
-    },
-    {
-      title: "Get tenant variables from Octopus Deploy",
-      readOnlyHint: true,
+      inputSchema: {
+        spaceName: z.string().describe("The space name"),
+        tenantId: z.string().describe("The ID of the tenant to retrieve variables for"),
+        variableType: z.enum(["all", "common", "project"]).describe("Type of variables to retrieve"),
+        includeMissingVariables: z.boolean().optional().describe("Include missing variables in the response (for common/project types)")
+      },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async ({ spaceName, tenantId, variableType, includeMissingVariables = false }) => {
       validateEntityId(tenantId, 'tenant', ENTITY_PREFIXES.tenant);

--- a/src/tools/getVariables.ts
+++ b/src/tools/getVariables.ts
@@ -8,24 +8,25 @@ import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import type {ResourceCollection} from "@octopusdeploy/api-client/dist/resourceCollection.js";
 
 export function registerGetVariablesTool(server: McpServer) {
-    server.tool(
+    server.registerTool(
         "get_variables",
-        `This tool gets all project and library variable set variables for a given project. 
-        Projects can contain variables (specific to a project), library variable sets (shared collections of variables associated with many projects), 
+        {
+            title: "Get variables for a Project from Octopus Deploy",
+            description: `This tool gets all project and library variable set variables for a given project.
+        Projects can contain variables (specific to a project), library variable sets (shared collections of variables associated with many projects),
         and tenant variables (variables related to a tenants connected to the project)
         If you want to retrieve tenant variables for a tenant connected to the project, use the get_tenant_variables tool.
         `,
-        {
-            spaceName: z.string().describe("The space name"),
-            projectId: z.string().describe("The ID of the project to retrieve the variables for"),
-            gitRef: z.string().describe("The gitRef to retrieve the variables from, if the project is a config-as-code project").optional(),
-        },
-        {
-            title: "Get variables for a Project from Octopus Deploy",
-            readOnlyHint: true,
+            inputSchema: {
+                spaceName: z.string().describe("The space name"),
+                projectId: z.string().describe("The ID of the project to retrieve the variables for"),
+                gitRef: z.string().describe("The gitRef to retrieve the variables from, if the project is a config-as-code project").optional(),
+            },
+            annotations: READ_ONLY_TOOL_ANNOTATIONS,
         },
         async ({ spaceName, projectId, gitRef }) => {
 

--- a/src/tools/grepTaskLog.ts
+++ b/src/tools/grepTaskLog.ts
@@ -2,6 +2,7 @@ import { Client, SpaceServerTaskRepository } from "@octopusdeploy/api-client";
 import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import {
   validateEntityId,
@@ -208,7 +209,7 @@ Parameter conventions mirror GNU grep so the schema is self-explanatory:
 
 Response includes totalMatches (true count across the whole log), totalLines, the matched lines with 1-indexed lineNumber, optional before/after context arrays, and a taskDetailsResourceUri for the structured fall-through.`,
       inputSchema,
-      annotations: { readOnlyHint: true },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async (args) => {
       const params = args as GrepTaskLogParams;

--- a/src/tools/listDeployments.ts
+++ b/src/tools/listDeployments.ts
@@ -3,27 +3,28 @@ import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { getPublicUrl } from "../helpers/getPublicUrl.js";
 
 export function registerListDeploymentsTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "list_deployments",
-    `List deployments in a space
-  
-  This tool lists deployments in a given space. The space name is required. When requesting latest deployment consider which deployment state the user is interested in (successful or all). Optional filters include: projects (array of project IDs), environments (array of environment IDs), tenants (array of tenant IDs), channels (array of channel IDs), taskState (one of: Canceled, Cancelling, Executing, Failed, Queued, Success, TimedOut), and take (number of results to return).`,
-    {
-      spaceName: z.string(),
-      projects: z.array(z.string()).optional(),
-      environments: z.array(z.string()).optional(),
-      tenants: z.array(z.string()).optional(),
-      channels: z.array(z.string()).optional(),
-      taskState: z.enum(["Canceled", "Cancelling", "Executing", "Failed", "Queued", "Success", "TimedOut"]).optional(),
-      skip: z.number().optional(),
-      take: z.number().optional()
-    },
     {
       title: "List deployments in an Octopus Deploy space",
-      readOnlyHint: true,
+      description: `List deployments in a space
+
+  This tool lists deployments in a given space. The space name is required. When requesting latest deployment consider which deployment state the user is interested in (successful or all). Optional filters include: projects (array of project IDs), environments (array of environment IDs), tenants (array of tenant IDs), channels (array of channel IDs), taskState (one of: Canceled, Cancelling, Executing, Failed, Queued, Success, TimedOut), and take (number of results to return).`,
+      inputSchema: {
+        spaceName: z.string(),
+        projects: z.array(z.string()).optional(),
+        environments: z.array(z.string()).optional(),
+        tenants: z.array(z.string()).optional(),
+        channels: z.array(z.string()).optional(),
+        taskState: z.enum(["Canceled", "Cancelling", "Executing", "Failed", "Queued", "Success", "TimedOut"]).optional(),
+        skip: z.number().optional(),
+        take: z.number().optional()
+      },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async ({ spaceName, projects, environments, tenants, channels, taskState, skip, take }) => {
       const configuration = getClientConfigurationFromEnvironment();

--- a/src/tools/listEnvironments.ts
+++ b/src/tools/listEnvironments.ts
@@ -7,23 +7,24 @@ import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { handleOctopusApiError } from "../helpers/errorHandling.js";
 
 export function registerListEnvironmentsTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "list_environments",
-    `List environments in a space
-
-  This tool lists all environments in a given space. The space name is required. Use this tool as early as possible to understand which environments are configured. Optionally filter by partial name match using partialName parameter.`,
-    {
-      spaceName: z.string(),
-      partialName: z.string().optional(),
-      skip: z.number().optional(),
-      take: z.number().optional(),
-    },
     {
       title: "List all environments in an Octopus Deploy space",
-      readOnlyHint: true,
+      description: `List environments in a space
+
+  This tool lists all environments in a given space. The space name is required. Use this tool as early as possible to understand which environments are configured. Optionally filter by partial name match using partialName parameter.`,
+      inputSchema: {
+        spaceName: z.string(),
+        partialName: z.string().optional(),
+        skip: z.number().optional(),
+        take: z.number().optional(),
+      },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async ({ spaceName, partialName, skip, take }) => {
       try {

--- a/src/tools/listProjects.ts
+++ b/src/tools/listProjects.ts
@@ -6,23 +6,24 @@ import {
 import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { projectsDescription } from "../types/projectTypes.js";
 import { handleOctopusApiError } from "../helpers/errorHandling.js";
 
 export function registerListProjectsTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "list_projects",
-    `This tool lists all projects in a given space. ${projectsDescription} The space name is required, if you can't find the space name, ask the user directly for the name of the space. Optionally filter by partial name match using partialName parameter.`,
-    {
-      spaceName: z.string(),
-      partialName: z.string().optional(),
-      skip: z.number().optional(),
-      take: z.number().optional(),
-    },
     {
       title: "List all projects in an Octopus Deploy space",
-      readOnlyHint: true,
+      description: `This tool lists all projects in a given space. ${projectsDescription} The space name is required, if you can't find the space name, ask the user directly for the name of the space. Optionally filter by partial name match using partialName parameter.`,
+      inputSchema: {
+        spaceName: z.string(),
+        partialName: z.string().optional(),
+        skip: z.number().optional(),
+        take: z.number().optional(),
+      },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async ({ spaceName, partialName, skip, take }) => {
       try {

--- a/src/tools/listSpaces.ts
+++ b/src/tools/listSpaces.ts
@@ -3,21 +3,22 @@ import { z } from "zod";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { spacesDescription } from "../types/spaceTypes.js";
 import { handleOctopusApiError } from "../helpers/errorHandling.js";
 
 export function registerListSpacesTool(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "list_spaces",
-    `List all spaces in the Octopus Deploy instance. ${spacesDescription} Always use this tool first to check that the requested space exists.`,
-    {
-      partialName: z.string().optional(),
-      skip: z.number().optional(),
-      take: z.number().optional(),
-    },
     {
       title: "List all spaces in an Octopus Deploy instance",
-      readOnlyHint: true,
+      description: `List all spaces in the Octopus Deploy instance. ${spacesDescription} Always use this tool first to check that the requested space exists.`,
+      inputSchema: {
+        partialName: z.string().optional(),
+        skip: z.number().optional(),
+        take: z.number().optional(),
+      },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async ({ partialName, skip, take }) => {
       try {

--- a/src/tools/readResource.ts
+++ b/src/tools/readResource.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { dispatchOctopusUri } from "../resources/dispatch.js";
 
 export function registerReadResourceTool(server: McpServer) {
@@ -26,7 +27,7 @@ Note: there is intentionally no octopus://...tasks/{id}/log resource. Call the g
             "Any 'octopus://...' URI returned by another tool (e.g. in the resourceUri or taskResourceUri field).",
           ),
       },
-      annotations: { readOnlyHint: true },
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async ({ uri }) => {
       const payload = await dispatchOctopusUri(uri);

--- a/src/types/toolAnnotations.ts
+++ b/src/types/toolAnnotations.ts
@@ -1,0 +1,31 @@
+import { type ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+
+// Every tool in this server hits a single user-configured Octopus instance with
+// a fixed entity schema (releases, projects, environments, machines, tenants,
+// ...). The SDK contrasts "web search" (open) with "memory tool" (closed); we
+// fall on the closed side.
+const CLOSED_WORLD = { openWorldHint: false } as const;
+
+/** Read-only Octopus query tool: list/find/get/grep/read_resource. */
+export const READ_ONLY_TOOL_ANNOTATIONS: ToolAnnotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  ...CLOSED_WORLD,
+};
+
+/** Write tool whose effect is purely additive — creates a new record, no overwrite. */
+export const ADDITIVE_WRITE_TOOL_ANNOTATIONS: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: false,
+  ...CLOSED_WORLD,
+};
+
+/** Write tool that may overwrite or otherwise mutate live state. */
+export const DESTRUCTIVE_WRITE_TOOL_ANNOTATIONS: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: false,
+  ...CLOSED_WORLD,
+};


### PR DESCRIPTION
## Summary

- Migrate the remaining 18 tools from deprecated `server.tool(...)` to `server.registerTool(...)`. After this PR, all 22 tools use the new API and the only `server.tool(` references in `src/` are zero.
- Centralize MCP `ToolAnnotations` in a new `src/types/toolAnnotations.ts` exporting three profiles — `READ_ONLY_TOOL_ANNOTATIONS`, `ADDITIVE_WRITE_TOOL_ANNOTATIONS`, `DESTRUCTIVE_WRITE_TOOL_ANNOTATIONS` — so every tool sets all four hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) instead of only `readOnlyHint`.
- All three profiles set `openWorldHint: false`. The SDK contrasts "web search" (open) with "memory tool" (closed); this server is bound to a single configured Octopus instance with a fixed entity schema, which is closer to closed-world. The [MCP blog post](https://blog.modelcontextprotocol.io/posts/2026-03-16-tool-annotations/) explicitly calls `openWorldHint` "the hint most sensitive to deployment context" — `false` is the honest signal for a corporate-internal Octopus instance.
- Per-write semantics:
  - `create_release` → `ADDITIVE_WRITE_TOOL_ANNOTATIONS` (`destructiveHint: false` — it adds a new release record, doesn't overwrite).
  - `deploy_release` → `DESTRUCTIVE_WRITE_TOOL_ANNOTATIONS` (`destructiveHint: true` — it triggers a deployment that mutates running environment state).
- Update `CLAUDE.md` with an "Annotation constants" subsection that points new tools at the constants instead of inline annotation literals.

No tool names, descriptions, input schemas, handler logic, or `requireConfirmation` write-gate flow changed.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm test` — 81 / 85 unit tests pass; the 4 failures are in `listTenants.integration.test.ts` and require a live Octopus instance with a space named "Octopus Server" (pre-existing environmental, unrelated)
- [x] `grep server.tool(` in `src/` returns zero matches; `grep server.registerTool(` returns 22 files
- [ ] Smoke-test against a real Octopus: drive `list_spaces`, `list_projects`, `find_releases` (read profile), `create_release` (additive write — verify elicitation/confirm gate still triggers), `deploy_release` (destructive write — same)
- [ ] Confirm via MCP Inspector that each tool now advertises the four hints with the expected values, particularly that `deploy_release` shows `destructiveHint: true` and `create_release` shows `destructiveHint: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)