### PR TITLE
feat: Add llms.txt catalog and execute backstop with hard read/write/delete gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ See [Working with URLs](docs/working-with-urls.md) for detailed workflows, examp
 
 These tools and resources let the agent reach Octopus REST endpoints that don't have a dedicated curated tool, with hard server-side gating between read, write, and delete operations.
 
-- `grep_llms_txt`: Search the Octopus API catalog (`octopus://api/llms.txt`) with grep-style semantics. The catalog body is large (typically 300+ KB) — call this rather than reading the resource body directly. Parameters mirror GNU grep (`pattern`, `caseInsensitive`, `invertMatch`, `fixedString`, `beforeContext`, `afterContext`, `maxCount`). Useful for discovering endpoints (`POST /releases`), enumerating delete endpoints (`DELETE `), or finding the body type for a write operation (`Body: Create.*Command`).
+- `grep_llms_txt`: Search the Octopus API catalog (`octopus://api/llms.txt`) with grep-style semantics (minimum supported Octopus version: `2026.2.3916`). The catalog body is large (typically 300+ KB) — call this rather than reading the resource body directly. Parameters mirror GNU grep (`pattern`, `caseInsensitive`, `invertMatch`, `fixedString`, `beforeContext`, `afterContext`, `maxCount`). Useful for discovering endpoints (`POST /releases`), enumerating delete endpoints (`DELETE `), or finding the body type for a write operation (`Body: Create.*Command`).
 - `execute`: Structured REST backstop. Reaches any Octopus endpoint covered by the per-toolset path allowlist. The HTTP method is the authoritative read/write/delete classifier — never an `isWrite` flag the LLM can set. Method gating is hard-coded server-side:
    - `GET` is always allowed (subject to the path allowlist + sensitive denylist).
    - `POST`/`PUT`/`PATCH` require `--no-read-only` plus user confirmation via elicitation.
@@ -312,7 +312,7 @@ These tools and resources let the agent reach Octopus REST endpoints that don't 
 
 Catalog data is also exposed as MCP Resources:
 
-- `octopus://api/llms.txt` — markdown catalog of every Octopus REST endpoint (HTTP method, path, query params, request/response types). 5-minute in-memory cache keyed on the configured server URL. **Prefer `grep_llms_txt` to reading the body directly.**
+- `octopus://api/llms.txt` — markdown catalog of every Octopus REST endpoint (HTTP method, path, query params, request/response types). Requires Octopus Server `2026.2.3916` or later. 5-minute in-memory cache keyed on the configured server URL. **Prefer `grep_llms_txt` to reading the body directly.**
 - `octopus://api/capabilities` — JSON describing the running session: server version, enabled toolsets, available tools (with their `minimumOctopusVersion`), and whether read-only / `--allow-deletes` mode is on. Useful for the agent to discover what's reachable in this session.
 
 ### Projects

--- a/README.md
+++ b/README.md
@@ -202,24 +202,33 @@ Available toolsets:
 #### Read-Only Mode
 The server runs in read-only mode by default for security. Most tools are read-only operations, but some tools can perform write operations (like creating releases and deployments).
 
-**Write-enabled tools:**
+**Write-enabled tools (always-write):**
 - `create_release` - Create new releases
 - `deploy_release` - Deploy releases to environments and tenants
 - `run_runbook` - Run a runbook against one or more environments (and optional tenants)
 
+**Conditionally-writing tool:** `execute` is a structured REST backstop whose tier (read / write / delete) is determined by the HTTP method passed to it. See the [API Catalog & Backstop](#api-catalog--backstop) section for details.
+
 Write tools are gated by an MCP elicitation prompt: clients that support elicitation will be asked to confirm before the call proceeds. Clients without elicitation support must pass `confirm: true` in the tool arguments — otherwise the tool aborts with an error. Set `OCTOPUS_SKIP_ELICITATION=true` to bypass the gate entirely (intended for unattended automation).
 
-To use write-enabled tools, you must explicitly disable read-only mode:
+The server uses a three-tier read/write/delete classification, enforced server-side based on the HTTP method (the agent cannot bypass this by lying about intent):
+
+- **read** — always allowed. GET requests through `execute`, plus all `find_*` / `get_*` / `list_*` tools.
+- **write** — POST/PUT/PATCH through `execute` and the always-write tools above. Requires `--no-read-only`.
+- **delete** — DELETE through `execute`. Requires `--no-read-only` AND `--allow-deletes` (a deliberate two-flag opt-in for irreversible operations). A small set of catastrophic-delete paths (e.g. `DELETE /api/spaces/{id}`, `DELETE /api/users/{id}`) and API-key endpoints are on a hard sensitive denylist that ignores both flags.
 
 ```bash
-# Run in read-only mode (default) - write tools are disabled
+# Run in read-only mode (default) - write/delete tools are disabled
 npx -y @octopusdeploy/mcp-server
 
-# Disable read-only mode to enable write operations
+# Disable read-only mode to enable write operations (POST/PUT/PATCH)
 npx -y @octopusdeploy/mcp-server --no-read-only
+
+# Additionally permit DELETE requests through the execute tool
+npx -y @octopusdeploy/mcp-server --no-read-only --allow-deletes
 ```
 
-**Security Note:** When disabling read-only mode, ensure you use an API key with appropriate, least-privilege permissions. Write operations can create releases and trigger deployments in your Octopus instance.
+**Security Note:** When disabling read-only mode, ensure you use an API key with appropriate, least-privilege permissions. Write operations can create releases and trigger deployments in your Octopus instance. `--allow-deletes` is off by default; only enable it when the agent must issue DELETE requests through `execute`.
 
 #### Complete Examples
 
@@ -238,6 +247,8 @@ npx -y @octopusdeploy/mcp-server --no-read-only --server-url https://your-octopu
 
 #### Other command line arguments
 
+* `--no-read-only` - Disable read-only mode, enabling POST/PUT/PATCH through the curated write tools and through `execute`. See [Read-Only Mode](#read-only-mode).
+* `--allow-deletes` - Additionally permit DELETE requests through the `execute` tool. Requires `--no-read-only`. Default `false`.
 * `--log-level <level>` - Minimum log level (info, error)
 * `--log-file <path>` - Log file path or filename. If not specified, logs are written to console only
 * `-q, --quiet` - Disable file logging, only log errors to console
@@ -286,6 +297,23 @@ See [Working with URLs](docs/working-with-urls.md) for detailed workflows, examp
 ### Core Tools
 - `list_spaces`: List all spaces in the Octopus Deploy instance
 - `list_environments`: List all environments in a given space
+
+### API Catalog & Backstop
+
+These tools and resources let the agent reach Octopus REST endpoints that don't have a dedicated curated tool, with hard server-side gating between read, write, and delete operations.
+
+- `grep_llms_txt`: Search the Octopus API catalog (`octopus://api/llms.txt`) with grep-style semantics. The catalog body is large (typically 300+ KB) — call this rather than reading the resource body directly. Parameters mirror GNU grep (`pattern`, `caseInsensitive`, `invertMatch`, `fixedString`, `beforeContext`, `afterContext`, `maxCount`). Useful for discovering endpoints (`POST /releases`), enumerating delete endpoints (`DELETE `), or finding the body type for a write operation (`Body: Create.*Command`).
+- `execute`: Structured REST backstop. Reaches any Octopus endpoint covered by the per-toolset path allowlist. The HTTP method is the authoritative read/write/delete classifier — never an `isWrite` flag the LLM can set. Method gating is hard-coded server-side:
+   - `GET` is always allowed (subject to the path allowlist + sensitive denylist).
+   - `POST`/`PUT`/`PATCH` require `--no-read-only` plus user confirmation via elicitation.
+   - `DELETE` requires `--no-read-only` AND `--allow-deletes` plus a stronger "IRREVERSIBLE" elicitation message.
+   - The sensitive denylist (API-key endpoints, `DELETE /api/spaces/{id}`, `DELETE /api/users/{id}`) is enforced even with both flags on.
+   - The path allowlist is scoped per toolset — disabling a toolset (e.g. `audit`) makes its paths unreachable through `execute`.
+
+Catalog data is also exposed as MCP Resources:
+
+- `octopus://api/llms.txt` — markdown catalog of every Octopus REST endpoint (HTTP method, path, query params, request/response types). 5-minute in-memory cache keyed on the configured server URL. **Prefer `grep_llms_txt` to reading the body directly.**
+- `octopus://api/capabilities` — JSON describing the running session: server version, enabled toolsets, available tools (with their `minimumOctopusVersion`), and whether read-only / `--allow-deletes` mode is on. Useful for the agent to discover what's reachable in this session.
 
 ### Projects
 - `list_projects`: List all projects in a given space
@@ -354,16 +382,22 @@ The Octopus MCP Server includes both read and write operations. Important securi
 - Exercise caution when connecting to tools and models you do not fully trust
 
 ### Write Operations
-When read-only mode is disabled (`--no-read-only`), the following write operations are available:
+When read-only mode is disabled (`--no-read-only`), the following write operations become available:
 - **Creating releases**: Can create new releases for projects
 - **Deploying releases**: Can trigger deployments to environments (including production)
+- **Running runbooks**: Can execute runbooks against environments and tenants
+- **Arbitrary POST/PUT/PATCH via the `execute` backstop**: Subject to the per-toolset path allowlist and a sensitive denylist that's always-on.
+
+DELETE requests through `execute` require an additional `--allow-deletes` flag — a deliberate two-flag opt-in for irreversible operations.
 
 **Critical Security Measures:**
 1. **Least Privilege**: Use API keys with the minimum permissions needed for your use case
-2. **Read-Only by Default**: The server defaults to read-only mode - you must explicitly opt-in to write operations
-3. **Prompt Injection Risk**: Running agents in fully automated fashion could make you vulnerable to prompt-injection attacks
+2. **Read-Only by Default**: The server defaults to read-only mode — you must explicitly opt-in to write operations, and again to DELETE.
+3. **Method gating is server-side and hard-coded**: The HTTP method passed to `execute` is the authoritative classifier. The agent cannot bypass the gate by misrepresenting what the call does — POST/PUT/PATCH/DELETE requests get tier-specific gating regardless of the prose in the request body.
+4. **Toolset filtering doubles as a kill switch**: Disabling a toolset removes both its curated tools and its paths from the `execute` allowlist.
+5. **Prompt Injection Risk**: Running agents in fully automated fashion could make you vulnerable to prompt-injection attacks
 
-**Recommendation**: For production environments, use read-only mode unless you have a specific, controlled use case for write operations.
+**Recommendation**: For production environments, use read-only mode unless you have a specific, controlled use case for write operations. Leave `--allow-deletes` off unless you specifically need DELETE semantics through `execute`.
 
 ## ⚠️ Limitations
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ npx -y @octopusdeploy/mcp-server --no-read-only
 npx -y @octopusdeploy/mcp-server --no-read-only --allow-deletes
 ```
 
-**Security Note:** When disabling read-only mode, ensure you use an API key with appropriate, least-privilege permissions. Write operations can create releases and trigger deployments in your Octopus instance. `--allow-deletes` is off by default; only enable it when the agent must issue DELETE requests through `execute`.
+**Security Note:** When disabling read-only mode, ensure you use an API key with appropriate, least-privilege permissions. Write operations can create releases and trigger deployments in your Octopus instance. `--allow-deletes` is off by default; only enable it when the agent must issue DELETE requests through `execute`. If you pass `--allow-deletes` without `--no-read-only`, the server prints a startup warning to stderr — DELETE requests still go through the read-only gate first and remain blocked.
 
 #### Complete Examples
 
@@ -308,7 +308,7 @@ These tools and resources let the agent reach Octopus REST endpoints that don't 
    - `POST`/`PUT`/`PATCH` require `--no-read-only` plus user confirmation via elicitation.
    - `DELETE` requires `--no-read-only` AND `--allow-deletes` plus a stronger "IRREVERSIBLE" elicitation message.
    - The sensitive denylist (API-key endpoints, `DELETE /api/spaces/{id}`, `DELETE /api/users/{id}`) is enforced even with both flags on.
-   - The path allowlist is scoped per toolset — disabling a toolset (e.g. `audit`) makes its paths unreachable through `execute`.
+   - The path allowlist is scoped per toolset — disabling a toolset (e.g. `certificates`) makes its paths unreachable through `execute`, even on GET.
 
 Catalog data is also exposed as MCP Resources:
 

--- a/src/helpers/__tests__/grepLines.test.ts
+++ b/src/helpers/__tests__/grepLines.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { grepLines } from "../grepTaskLog.js";
+import { grepLines } from "../grepLines.js";
 
 const SAMPLE_LOG = [
   "2026-05-05T12:00:00 Info  | Step 1 starting",
@@ -13,9 +13,11 @@ const SAMPLE_LOG = [
   "",
 ].join("\n");
 
+// Pure-function tests — `grepLines` does not consume spaceName/taskId, but
+// the test body originated in a tool-level test file where those were the
+// outer parameters. Kept as `baseParams` rather than removing them so the
+// per-test diffs stay minimal during the migration.
 const baseParams = {
-  spaceName: "Default",
-  taskId: "ServerTasks-1",
   pattern: "",
 };
 

--- a/src/helpers/__tests__/methodTier.test.ts
+++ b/src/helpers/__tests__/methodTier.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { classifyMethod, HTTP_METHODS } from "../methodTier.js";
+
+describe("classifyMethod", () => {
+  it("classifies GET as the read tier", () => {
+    expect(classifyMethod("GET")).toBe("read");
+  });
+
+  it("classifies POST, PUT, PATCH as the write tier", () => {
+    expect(classifyMethod("POST")).toBe("write");
+    expect(classifyMethod("PUT")).toBe("write");
+    expect(classifyMethod("PATCH")).toBe("write");
+  });
+
+  it("classifies DELETE as its own delete tier (separate from write)", () => {
+    expect(classifyMethod("DELETE")).toBe("delete");
+  });
+
+  it("HTTP_METHODS enumerates exactly the five supported verbs", () => {
+    expect([...HTTP_METHODS].sort()).toEqual([
+      "DELETE",
+      "GET",
+      "PATCH",
+      "POST",
+      "PUT",
+    ]);
+  });
+});

--- a/src/helpers/__tests__/pathAllowlist.test.ts
+++ b/src/helpers/__tests__/pathAllowlist.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { matchPath, findOwningToolset } from "../pathAllowlist.js";
+
+describe("matchPath", () => {
+  it("allows core paths even when no toolsets are enabled", () => {
+    expect(matchPath("/api/spaces", [])).toMatchObject({
+      matched: true,
+      toolset: "core",
+    });
+    expect(matchPath("/api/users/me", [])).toMatchObject({
+      matched: true,
+      toolset: "core",
+    });
+    expect(matchPath("/api/experimental/llms.txt", [])).toMatchObject({
+      matched: true,
+      toolset: "core",
+    });
+  });
+
+  it("blocks toolset-scoped paths when their toolset is not enabled", () => {
+    expect(matchPath("/api/Spaces-1/projects", [])).toMatchObject({
+      matched: false,
+    });
+    expect(matchPath("/api/Spaces-1/releases", [])).toMatchObject({
+      matched: false,
+    });
+  });
+
+  it("allows a path when the matching toolset is enabled", () => {
+    expect(matchPath("/api/Spaces-1/projects", ["projects"])).toMatchObject({
+      matched: true,
+      toolset: "projects",
+    });
+    expect(
+      matchPath("/api/Spaces-1/releases/Releases-1", ["releases"]),
+    ).toMatchObject({ matched: true, toolset: "releases" });
+  });
+
+  it("supports both space-prefix forms via the * single-segment wildcard", () => {
+    expect(
+      matchPath("/api/Spaces-1/projects/Projects-1", ["projects"]),
+    ).toMatchObject({ matched: true });
+    expect(
+      matchPath("/api/spaces/Spaces-1/projects/Projects-1", ["projects"]),
+    ).toMatchObject({ matched: true });
+    expect(
+      matchPath("/api/spaces/default/projects/Projects-1", ["projects"]),
+    ).toMatchObject({ matched: true });
+  });
+
+  it("`**` matches across multiple segments", () => {
+    expect(
+      matchPath(
+        "/api/Spaces-1/projects/Projects-1/deploymentprocesses/snapshot",
+        ["projects"],
+      ),
+    ).toMatchObject({ matched: true });
+  });
+
+  it("does not match when the path falls outside any enabled toolset", () => {
+    expect(matchPath("/api/Spaces-1/certificates", ["projects"])).toMatchObject(
+      { matched: false },
+    );
+  });
+});
+
+describe("findOwningToolset", () => {
+  it("names the toolset that owns a given path even when not enabled", () => {
+    expect(findOwningToolset("/api/Spaces-1/certificates")).toBe("certificates");
+    expect(findOwningToolset("/api/Spaces-1/runbooks/Runbooks-1")).toBe(
+      "runbooks",
+    );
+  });
+
+  it("returns undefined for paths no toolset claims", () => {
+    expect(findOwningToolset("/api/something/never/registered")).toBeUndefined();
+  });
+});

--- a/src/helpers/__tests__/pathAllowlist.test.ts
+++ b/src/helpers/__tests__/pathAllowlist.test.ts
@@ -36,16 +36,16 @@ describe("matchPath", () => {
     ).toMatchObject({ matched: true, toolset: "releases" });
   });
 
-  it("supports both space-prefix forms via the * single-segment wildcard", () => {
+  it("supports both space-prefix forms — bare spaceId AND /spaces/{slug-or-id}", () => {
     expect(
       matchPath("/api/Spaces-1/projects/Projects-1", ["projects"]),
-    ).toMatchObject({ matched: true });
+    ).toMatchObject({ matched: true, toolset: "projects" });
     expect(
       matchPath("/api/spaces/Spaces-1/projects/Projects-1", ["projects"]),
-    ).toMatchObject({ matched: true });
+    ).toMatchObject({ matched: true, toolset: "projects" });
     expect(
       matchPath("/api/spaces/default/projects/Projects-1", ["projects"]),
-    ).toMatchObject({ matched: true });
+    ).toMatchObject({ matched: true, toolset: "projects" });
   });
 
   it("`**` matches across multiple segments", () => {
@@ -61,6 +61,39 @@ describe("matchPath", () => {
     expect(matchPath("/api/Spaces-1/certificates", ["projects"])).toMatchObject(
       { matched: false },
     );
+  });
+
+  it("core does NOT pass through space sub-paths — toolset filtering is the kill switch", () => {
+    // Codex regression: previously `core: /api/spaces/**` swallowed every
+    // space-scoped path and short-circuited per-toolset gating. With core
+    // narrowed, the /spaces/{id}/... form must require the owning toolset.
+    expect(
+      matchPath("/api/spaces/Spaces-1/certificates", ["projects"]),
+    ).toMatchObject({ matched: false });
+    expect(
+      matchPath("/api/spaces/Spaces-1/certificates", ["certificates"]),
+    ).toMatchObject({ matched: true, toolset: "certificates" });
+    expect(
+      matchPath("/api/spaces/Spaces-1/runbookruns/RunbookRuns-1", []),
+    ).toMatchObject({ matched: false });
+    expect(
+      matchPath("/api/spaces/Spaces-1/runbookruns/RunbookRuns-1", ["runbooks"]),
+    ).toMatchObject({ matched: true, toolset: "runbooks" });
+  });
+
+  it("core still allows top-level Space metadata so the space resolver works", () => {
+    expect(matchPath("/api/spaces", [])).toMatchObject({
+      matched: true,
+      toolset: "core",
+    });
+    expect(matchPath("/api/spaces/Spaces-1", [])).toMatchObject({
+      matched: true,
+      toolset: "core",
+    });
+    expect(matchPath("/api/spaces/default", [])).toMatchObject({
+      matched: true,
+      toolset: "core",
+    });
   });
 });
 

--- a/src/helpers/__tests__/sensitivePathDenylist.test.ts
+++ b/src/helpers/__tests__/sensitivePathDenylist.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { isSensitive } from "../sensitivePathDenylist.js";
+
+describe("isSensitive", () => {
+  it("blocks API key endpoints regardless of method", () => {
+    expect(isSensitive("GET", "/api/users/Users-1/apikeys")).toMatchObject({
+      blocked: true,
+    });
+    expect(isSensitive("POST", "/api/users/me/apikeys")).toMatchObject({
+      blocked: true,
+    });
+    expect(
+      isSensitive("DELETE", "/api/users/Users-1/apikeys/ApiKeys-99"),
+    ).toMatchObject({ blocked: true });
+  });
+
+  it("blocks user deletion via DELETE /api/users/{id} but not GET on the same path", () => {
+    expect(isSensitive("DELETE", "/api/users/Users-1")).toMatchObject({
+      blocked: true,
+    });
+    expect(isSensitive("GET", "/api/users/Users-1")).toMatchObject({
+      blocked: false,
+    });
+  });
+
+  it("blocks Space deletion via DELETE /api/spaces/{id}", () => {
+    expect(isSensitive("DELETE", "/api/spaces/Spaces-1")).toMatchObject({
+      blocked: true,
+    });
+  });
+
+  it("does not block DELETE on nested space resources (e.g. feeds inside a space)", () => {
+    expect(
+      isSensitive("DELETE", "/api/spaces/Spaces-1/feeds/Feeds-2"),
+    ).toMatchObject({ blocked: false });
+  });
+
+  it("does not over-match adjacent-but-distinct paths", () => {
+    expect(
+      isSensitive("GET", "/api/users/Users-1/permissions"),
+    ).toMatchObject({ blocked: false });
+    expect(isSensitive("POST", "/api/spaces")).toMatchObject({
+      blocked: false,
+    });
+  });
+
+  it("returns the entry's reason text when a path is blocked", () => {
+    const result = isSensitive("DELETE", "/api/spaces/Spaces-1");
+    expect(result.blocked).toBe(true);
+    expect(result.reason).toMatch(/catastrophic/i);
+  });
+
+  it("treats glob metacharacters in the path literally (no regex injection)", () => {
+    // A path containing regex metacharacters must not match anything outside
+    // the literal denylist patterns.
+    expect(isSensitive("GET", "/api/users/.+/apikeys")).toMatchObject({
+      blocked: true, // `*` matches one segment, `.+` is one segment → matches.
+    });
+    expect(isSensitive("GET", "/api/projects(.*)")).toMatchObject({
+      blocked: false, // not on the denylist; metacharacters are not honoured.
+    });
+  });
+});

--- a/src/helpers/__tests__/validateExecutePath.test.ts
+++ b/src/helpers/__tests__/validateExecutePath.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { validateExecutePath } from "../validateExecutePath.js";
+
+describe("validateExecutePath", () => {
+  it("accepts simple absolute paths", () => {
+    expect(validateExecutePath("/api/spaces")).toEqual({
+      ok: true,
+      path: "/api/spaces",
+    });
+    expect(
+      validateExecutePath("/api/Spaces-1/projects/Projects-1"),
+    ).toEqual({
+      ok: true,
+      path: "/api/Spaces-1/projects/Projects-1",
+    });
+  });
+
+  it("rejects empty or non-absolute paths", () => {
+    expect(validateExecutePath("")).toEqual({
+      ok: false,
+      reason: expect.stringContaining("non-empty"),
+    });
+    expect(validateExecutePath("api/spaces")).toEqual({
+      ok: false,
+      reason: expect.stringContaining("must start with"),
+    });
+  });
+
+  it("rejects '..' segments anywhere in the path", () => {
+    // The motivating bypass — Codex flagged this exact shape.
+    expect(
+      validateExecutePath("/api/spaces/Spaces-1/../../users/me/apikeys"),
+    ).toMatchObject({ ok: false });
+    expect(validateExecutePath("/../etc/passwd")).toMatchObject({ ok: false });
+    expect(validateExecutePath("/api/..")).toMatchObject({ ok: false });
+    // A segment that *contains* `..` but isn't exactly `..` is allowed
+    // (real Octopus IDs don't have this shape, but the rule is segment-exact
+    // to avoid false positives like "/api/foo..bar").
+    expect(validateExecutePath("/api/foo..bar")).toMatchObject({ ok: true });
+  });
+
+  it("rejects backslashes (Windows path injection)", () => {
+    expect(validateExecutePath("/api/spaces\\..\\users")).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("rejects query strings and fragments — they belong in dedicated args", () => {
+    expect(validateExecutePath("/api/spaces?take=10")).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("query string"),
+    });
+    expect(validateExecutePath("/api/spaces#section")).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("rejects percent-encoded slashes that would unhide a denylist path", () => {
+    // /api/users%2Fme%2Fapikeys would match a literal pattern but resolves
+    // to /api/users/me/apikeys after URL decoding.
+    expect(validateExecutePath("/api/users%2Fme%2Fapikeys")).toMatchObject({
+      ok: false,
+    });
+    expect(validateExecutePath("/api/users%2fme")).toMatchObject({ ok: false });
+    expect(validateExecutePath("/api/foo%5cbar")).toMatchObject({ ok: false });
+  });
+
+  it("rejects double slashes (allowlist anchoring assumes single-segment separators)", () => {
+    expect(validateExecutePath("/api//spaces")).toMatchObject({ ok: false });
+  });
+
+  it("permits percent-encoded characters that aren't slashes or backslashes", () => {
+    // Space names can be percent-encoded — `default%20space` is a legitimate
+    // segment value. Only %2F and %5C are dangerous.
+    expect(
+      validateExecutePath("/api/spaces/default%20space"),
+    ).toMatchObject({ ok: true });
+  });
+});

--- a/src/helpers/activeToolsetConfig.ts
+++ b/src/helpers/activeToolsetConfig.ts
@@ -1,0 +1,21 @@
+import { type ToolsetConfig } from "../types/toolConfig.js";
+
+/**
+ * Per-session ToolsetConfig holder.
+ *
+ * Resource handlers and the `execute` tool both register eagerly via
+ * side-effect imports, so they don't have access to the per-session config
+ * at module-eval time. registerResources writes the active config here at
+ * startup; the catalog/capabilities resource and execute tool read it on
+ * demand.
+ */
+
+let activeConfig: ToolsetConfig = {};
+
+export function setActiveToolsetConfig(config: ToolsetConfig): void {
+  activeConfig = config;
+}
+
+export function getActiveToolsetConfig(): ToolsetConfig {
+  return activeConfig;
+}

--- a/src/helpers/grepLines.ts
+++ b/src/helpers/grepLines.ts
@@ -1,0 +1,119 @@
+/**
+ * GNU-grep-shaped line search over a multi-line string. Pure function, used by
+ * grep_task_log (task activity logs) and grep_llms_txt (catalog markdown). Each
+ * line is tested independently; matching lines are emitted with optional
+ * symmetric context windows. Overlapping context between adjacent matches is
+ * NOT deduplicated — each match carries its own complete context window so the
+ * consumer can reason about each match in isolation. This is a deliberate
+ * departure from GNU grep's `--`-separated output but it is the right shape
+ * for a JSON tool response.
+ */
+
+export interface GrepLinesParams {
+  pattern: string;
+  caseInsensitive?: boolean;
+  invertMatch?: boolean;
+  fixedString?: boolean;
+  beforeContext?: number;
+  afterContext?: number;
+  maxCount?: number;
+}
+
+export interface ContextLine {
+  lineNumber: number;
+  line: string;
+}
+
+export interface GrepMatch {
+  lineNumber: number;
+  line: string;
+  before?: ContextLine[];
+  after?: ContextLine[];
+}
+
+export interface GrepLinesResult {
+  totalLines: number;
+  totalMatches: number;
+  matches: GrepMatch[];
+}
+
+export const MAX_CONTEXT = 50;
+export const MAX_COUNT_HARD_CAP = 500;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function compilePattern(
+  pattern: string,
+  caseInsensitive: boolean,
+  fixedString: boolean,
+): RegExp {
+  const source = fixedString ? escapeRegExp(pattern) : pattern;
+  const flags = caseInsensitive ? "i" : "";
+  try {
+    return new RegExp(source, flags);
+  } catch (error) {
+    throw new Error(
+      `Invalid pattern: ${error instanceof Error ? error.message : String(error)}. ` +
+        "Set fixedString:true to treat the pattern as a literal substring instead of a regex.",
+    );
+  }
+}
+
+export function grepLines(
+  rawText: string,
+  params: GrepLinesParams,
+): GrepLinesResult {
+  const {
+    pattern,
+    caseInsensitive = false,
+    invertMatch = false,
+    fixedString = false,
+    beforeContext = 0,
+    afterContext = 0,
+    maxCount = 100,
+  } = params;
+
+  const lines = rawText.split("\n");
+  // Drop the trailing empty element produced by a final newline.
+  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+
+  const regex = compilePattern(pattern, caseInsensitive, fixedString);
+
+  const matches: GrepMatch[] = [];
+  let totalMatches = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const isMatch = regex.test(lines[i]) !== invertMatch;
+    if (!isMatch) continue;
+
+    totalMatches++;
+    if (matches.length >= maxCount) continue;
+
+    const match: GrepMatch = {
+      lineNumber: i + 1,
+      line: lines[i],
+    };
+
+    if (beforeContext > 0) {
+      const start = Math.max(0, i - beforeContext);
+      match.before = lines.slice(start, i).map((line, idx) => ({
+        lineNumber: start + idx + 1,
+        line,
+      }));
+    }
+
+    if (afterContext > 0) {
+      const end = Math.min(lines.length, i + 1 + afterContext);
+      match.after = lines.slice(i + 1, end).map((line, idx) => ({
+        lineNumber: i + 2 + idx,
+        line,
+      }));
+    }
+
+    matches.push(match);
+  }
+
+  return { totalLines: lines.length, totalMatches, matches };
+}

--- a/src/helpers/methodTier.ts
+++ b/src/helpers/methodTier.ts
@@ -1,0 +1,27 @@
+/**
+ * Hard-coded read/write/delete classification for HTTP methods used by the
+ * `execute` backstop tool. The HTTP method is the authoritative classifier —
+ * never something the LLM gets to set independently of the actual call.
+ *
+ * Tiers:
+ *   - read   → GET                       (always allowed, subject to allow/denylists)
+ *   - write  → POST, PUT, PATCH          (requires --no-read-only)
+ *   - delete → DELETE                    (requires --no-read-only AND --allow-deletes)
+ */
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+export type MethodTier = "read" | "write" | "delete";
+
+export const HTTP_METHODS: readonly HttpMethod[] = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+] as const;
+
+export function classifyMethod(method: HttpMethod): MethodTier {
+  if (method === "GET") return "read";
+  if (method === "DELETE") return "delete";
+  return "write";
+}

--- a/src/helpers/pathAllowlist.ts
+++ b/src/helpers/pathAllowlist.ts
@@ -1,30 +1,50 @@
-/**
- * Path allowlist for the `execute` backstop tool, scoped per toolset.
- *
- * The mapping says: "if toolset X is enabled, these path patterns are
- * reachable through execute". When a toolset is disabled, all of its patterns
- * disappear — so turning off `audit` means `/api/events*` is unreachable
- * regardless of HTTP method or read-only mode.
- *
- * The allowlist is deliberately conservative at launch. It enumerates paths
- * the existing curated tools already cover plus the obvious neighbours
- * (e.g. siblings of `/api/projects` like `/api/projects/{id}/channels`).
- * Expand based on real usage; do not pre-emptively enumerate every Octopus
- * endpoint up front.
- *
- * Pattern syntax is the shared `compilePathGlob` engine — `*` matches one
- * segment, `**` matches across segments. Patterns are anchored to the full
- * path, so `/api/projects` does NOT match `/api/projects/Projects-1`; use
- * `/api/projects/**` for the latter.
- *
- * Space-prefixed paths: many Octopus endpoints accept either
- * `/api/{spaceId}/...` or `/api/spaces/{spaceIdentifier}/...`. Both forms are
- * covered by `/api/*\/projects/**` (the leading `*` matches either the bare
- * space ID or the literal `spaces` segment, and `**` covers everything after).
- */
+// Path allowlist for the `execute` backstop tool, scoped per toolset.
+//
+// The mapping says: "if toolset X is enabled, these path patterns are
+// reachable through execute". When a toolset is disabled, all of its patterns
+// disappear — turning off `releases` makes the release endpoints unreachable
+// regardless of HTTP method or read-only mode. This is the kill-switch model.
+//
+// **`core` is intentionally narrow.** It only covers space discovery,
+// server-level metadata, and the API catalog. It does NOT contain a wildcard
+// over space sub-paths — every per-resource path under a space must be
+// registered against its owning toolset. Anything else would let `core`
+// (which is always enabled and consulted first) defeat per-toolset filtering
+// for every space-scoped endpoint.
+//
+// **Each toolset registers BOTH space-prefix forms.** Octopus accepts
+// `/api/{spaceId}/X` and `/api/spaces/{spaceIdentifier}/X` interchangeably, so
+// each toolset declares both — `/api/<single>/projects` covers the
+// bare-space-ID form, and `/api/spaces/<single>/projects` covers the
+// `/spaces/{slug-or-id}` form. The shared glob engine treats `*` as a single
+// segment, so both patterns are needed.
+//
+// Pattern syntax is the shared `compilePathGlob` engine — `*` matches one
+// segment, `**` matches across segments. Patterns are anchored to the full
+// path: `/api/projects` does NOT match `/api/projects/Projects-1`; use
+// `/api/projects/**` for the latter.
+//
+// The allowlist is deliberately conservative at launch — it enumerates paths
+// the existing curated tools already cover plus the obvious neighbours.
+// Expand based on real usage; do not pre-emptively enumerate every Octopus
+// endpoint up front.
 
 import { type Toolset } from "../types/toolConfig.js";
 import { pathMatchesGlob } from "./pathGlob.js";
+
+/**
+ * Helper: produce the two prefix forms for a space-scoped path suffix.
+ *   spacePrefixed("projects") → ["/api/* /projects", "/api/spaces/* /projects"]
+ * Returns the bare endpoint and the wildcard sub-path variants for both.
+ */
+function spaceScoped(suffix: string): readonly string[] {
+  return [
+    `/api/*/${suffix}`,
+    `/api/*/${suffix}/**`,
+    `/api/spaces/*/${suffix}`,
+    `/api/spaces/*/${suffix}/**`,
+  ];
+}
 
 const TOOLSET_PATH_PATTERNS: Record<Toolset, readonly string[]> = {
   core: [
@@ -32,77 +52,61 @@ const TOOLSET_PATH_PATTERNS: Record<Toolset, readonly string[]> = {
     "/api/users/me",
     "/api/users/me/permissions/**",
     "/api/spaces",
-    "/api/spaces/**",
+    // Top-level Space metadata only — single segment after `/api/spaces`.
+    // Per-resource paths beneath a space (`/api/spaces/{id}/projects`, etc.)
+    // are NOT in core; they live under their owning toolset.
+    "/api/spaces/*",
     "/api/serverstatus/**",
     "/api/experimental/**",
   ],
   projects: [
-    "/api/*/projects",
-    "/api/*/projects/**",
-    "/api/*/projectgroups",
-    "/api/*/projectgroups/**",
-    "/api/*/lifecycles",
-    "/api/*/lifecycles/**",
+    ...spaceScoped("projects"),
+    ...spaceScoped("projectgroups"),
+    ...spaceScoped("lifecycles"),
   ],
   deployments: [
-    "/api/*/deployments",
-    "/api/*/deployments/**",
-    "/api/*/deploymentprocesses",
-    "/api/*/deploymentprocesses/**",
-    "/api/*/dashboard/**",
+    ...spaceScoped("deployments"),
+    ...spaceScoped("deploymentprocesses"),
+    ...spaceScoped("dashboard"),
   ],
   releases: [
-    "/api/*/releases",
-    "/api/*/releases/**",
-    "/api/*/channels",
-    "/api/*/channels/**",
+    ...spaceScoped("releases"),
+    ...spaceScoped("channels"),
   ],
   runbooks: [
-    "/api/*/runbooks",
-    "/api/*/runbooks/**",
-    "/api/*/runbookruns",
-    "/api/*/runbookruns/**",
-    "/api/*/runbookprocesses",
-    "/api/*/runbookprocesses/**",
-    "/api/*/runbooksnapshots",
-    "/api/*/runbooksnapshots/**",
+    ...spaceScoped("runbooks"),
+    ...spaceScoped("runbookruns"),
+    ...spaceScoped("runbookprocesses"),
+    ...spaceScoped("runbooksnapshots"),
   ],
   tasks: ["/api/tasks", "/api/tasks/**"],
   tenants: [
-    "/api/*/tenants",
-    "/api/*/tenants/**",
-    "/api/*/tenantvariables",
-    "/api/*/tenantvariables/**",
+    ...spaceScoped("tenants"),
+    ...spaceScoped("tenantvariables"),
   ],
   kubernetes: [
     "/api/*/machines/*/livestatus/**",
     "/api/*/machines/*/connection/**",
+    "/api/spaces/*/machines/*/livestatus/**",
+    "/api/spaces/*/machines/*/connection/**",
   ],
   machines: [
-    "/api/*/machines",
-    "/api/*/machines/**",
-    "/api/*/workers",
-    "/api/*/workers/**",
-    "/api/*/workerpools",
-    "/api/*/workerpools/**",
+    ...spaceScoped("machines"),
+    ...spaceScoped("workers"),
+    ...spaceScoped("workerpools"),
   ],
   context: [
-    "/api/*/environments",
-    "/api/*/environments/**",
-    "/api/*/variables",
-    "/api/*/variables/**",
+    ...spaceScoped("environments"),
+    ...spaceScoped("variables"),
   ],
   certificates: [
-    "/api/*/certificates",
-    "/api/*/certificates/**",
+    ...spaceScoped("certificates"),
   ],
   accounts: [
-    "/api/*/accounts",
-    "/api/*/accounts/**",
+    ...spaceScoped("accounts"),
   ],
   interruptions: [
-    "/api/*/interruptions",
-    "/api/*/interruptions/**",
+    ...spaceScoped("interruptions"),
   ],
 };
 

--- a/src/helpers/pathAllowlist.ts
+++ b/src/helpers/pathAllowlist.ts
@@ -1,0 +1,151 @@
+/**
+ * Path allowlist for the `execute` backstop tool, scoped per toolset.
+ *
+ * The mapping says: "if toolset X is enabled, these path patterns are
+ * reachable through execute". When a toolset is disabled, all of its patterns
+ * disappear — so turning off `audit` means `/api/events*` is unreachable
+ * regardless of HTTP method or read-only mode.
+ *
+ * The allowlist is deliberately conservative at launch. It enumerates paths
+ * the existing curated tools already cover plus the obvious neighbours
+ * (e.g. siblings of `/api/projects` like `/api/projects/{id}/channels`).
+ * Expand based on real usage; do not pre-emptively enumerate every Octopus
+ * endpoint up front.
+ *
+ * Pattern syntax is the shared `compilePathGlob` engine — `*` matches one
+ * segment, `**` matches across segments. Patterns are anchored to the full
+ * path, so `/api/projects` does NOT match `/api/projects/Projects-1`; use
+ * `/api/projects/**` for the latter.
+ *
+ * Space-prefixed paths: many Octopus endpoints accept either
+ * `/api/{spaceId}/...` or `/api/spaces/{spaceIdentifier}/...`. Both forms are
+ * covered by `/api/*\/projects/**` (the leading `*` matches either the bare
+ * space ID or the literal `spaces` segment, and `**` covers everything after).
+ */
+
+import { type Toolset } from "../types/toolConfig.js";
+import { pathMatchesGlob } from "./pathGlob.js";
+
+const TOOLSET_PATH_PATTERNS: Record<Toolset, readonly string[]> = {
+  core: [
+    "/api",
+    "/api/users/me",
+    "/api/users/me/permissions/**",
+    "/api/spaces",
+    "/api/spaces/**",
+    "/api/serverstatus/**",
+    "/api/experimental/**",
+  ],
+  projects: [
+    "/api/*/projects",
+    "/api/*/projects/**",
+    "/api/*/projectgroups",
+    "/api/*/projectgroups/**",
+    "/api/*/lifecycles",
+    "/api/*/lifecycles/**",
+  ],
+  deployments: [
+    "/api/*/deployments",
+    "/api/*/deployments/**",
+    "/api/*/deploymentprocesses",
+    "/api/*/deploymentprocesses/**",
+    "/api/*/dashboard/**",
+  ],
+  releases: [
+    "/api/*/releases",
+    "/api/*/releases/**",
+    "/api/*/channels",
+    "/api/*/channels/**",
+  ],
+  runbooks: [
+    "/api/*/runbooks",
+    "/api/*/runbooks/**",
+    "/api/*/runbookruns",
+    "/api/*/runbookruns/**",
+    "/api/*/runbookprocesses",
+    "/api/*/runbookprocesses/**",
+    "/api/*/runbooksnapshots",
+    "/api/*/runbooksnapshots/**",
+  ],
+  tasks: ["/api/tasks", "/api/tasks/**"],
+  tenants: [
+    "/api/*/tenants",
+    "/api/*/tenants/**",
+    "/api/*/tenantvariables",
+    "/api/*/tenantvariables/**",
+  ],
+  kubernetes: [
+    "/api/*/machines/*/livestatus/**",
+    "/api/*/machines/*/connection/**",
+  ],
+  machines: [
+    "/api/*/machines",
+    "/api/*/machines/**",
+    "/api/*/workers",
+    "/api/*/workers/**",
+    "/api/*/workerpools",
+    "/api/*/workerpools/**",
+  ],
+  context: [
+    "/api/*/environments",
+    "/api/*/environments/**",
+    "/api/*/variables",
+    "/api/*/variables/**",
+  ],
+  certificates: [
+    "/api/*/certificates",
+    "/api/*/certificates/**",
+  ],
+  accounts: [
+    "/api/*/accounts",
+    "/api/*/accounts/**",
+  ],
+  interruptions: [
+    "/api/*/interruptions",
+    "/api/*/interruptions/**",
+  ],
+};
+
+export interface AllowlistMatch {
+  matched: boolean;
+  toolset?: Toolset;
+}
+
+/**
+ * Check whether `path` falls under the allowlist for any currently-enabled
+ * toolset. The `core` toolset is implicitly always enabled; callers do not
+ * need to include it in `enabledToolsets`.
+ */
+export function matchPath(
+  path: string,
+  enabledToolsets: readonly Toolset[],
+): AllowlistMatch {
+  const candidates: Toolset[] = [
+    "core",
+    ...enabledToolsets.filter((t) => t !== "core"),
+  ];
+  for (const toolset of candidates) {
+    for (const pattern of TOOLSET_PATH_PATTERNS[toolset]) {
+      if (pathMatchesGlob(path, pattern)) {
+        return { matched: true, toolset };
+      }
+    }
+  }
+  return { matched: false };
+}
+
+/**
+ * Find which toolset would have allowed `path` if it were enabled. Used to
+ * produce a helpful error response that names the toolset the user needs to
+ * turn on.
+ */
+export function findOwningToolset(path: string): Toolset | undefined {
+  for (const toolset of Object.keys(TOOLSET_PATH_PATTERNS) as Toolset[]) {
+    for (const pattern of TOOLSET_PATH_PATTERNS[toolset]) {
+      if (pathMatchesGlob(path, pattern)) {
+        return toolset;
+      }
+    }
+  }
+  return undefined;
+}

--- a/src/helpers/pathGlob.ts
+++ b/src/helpers/pathGlob.ts
@@ -1,0 +1,49 @@
+/**
+ * Tiny safe glob engine for matching Octopus REST paths in the `execute`
+ * tool's allowlist and sensitive denylist. Two wildcard tokens:
+ *
+ *   - `*`  matches a single path segment (no `/` allowed)
+ *   - `**` matches any sequence of characters, including `/`
+ *
+ * Every other character is treated literally — regex metacharacters are
+ * escaped at compile time, so denylist and allowlist entries cannot be turned
+ * into regex injection by a clever path. Patterns are anchored to the full
+ * input via `^…$`, so `/api/projects` does NOT match `/api/projects/Projects-1`.
+ */
+
+const COMPILED = new Map<string, RegExp>();
+
+export function compilePathGlob(pattern: string): RegExp {
+  const cached = COMPILED.get(pattern);
+  if (cached) return cached;
+
+  let regexSource = "";
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === "*") {
+      if (pattern[i + 1] === "*") {
+        regexSource += ".*";
+        i += 2;
+        continue;
+      }
+      regexSource += "[^/]+";
+      i += 1;
+      continue;
+    }
+    if (/[.+?^${}()|[\]\\]/.test(ch)) {
+      regexSource += "\\" + ch;
+    } else {
+      regexSource += ch;
+    }
+    i += 1;
+  }
+
+  const compiled = new RegExp("^" + regexSource + "$");
+  COMPILED.set(pattern, compiled);
+  return compiled;
+}
+
+export function pathMatchesGlob(path: string, pattern: string): boolean {
+  return compilePathGlob(pattern).test(path);
+}

--- a/src/helpers/sensitivePathDenylist.ts
+++ b/src/helpers/sensitivePathDenylist.ts
@@ -1,0 +1,72 @@
+/**
+ * Hard denylist for `execute` paths that must never be reachable, regardless
+ * of toolsets or mode flags. These are entries the user cannot opt into via
+ * --no-read-only or --allow-deletes.
+ *
+ * Two categories live here:
+ *   1. API-key management — creating or modifying API keys via the MCP server
+ *      is structurally out of scope (the agent uses a key already; minting more
+ *      from inside the agent is a privilege escalation pattern).
+ *   2. Catastrophic deletes — paths whose DELETE removes a top-level container
+ *      (a Space, a User) and is operationally irreversible. Allowing the agent
+ *      to issue these from a single tool call is too sharp an edge.
+ *
+ * Pattern syntax is the shared `compilePathGlob` engine: `*` matches one
+ * segment, `**` matches across segments, and every other character is literal.
+ */
+
+import { type HttpMethod } from "./methodTier.js";
+import { pathMatchesGlob } from "./pathGlob.js";
+
+export interface DenyEntry {
+  /** Optional method filter; absent = all methods. */
+  method?: HttpMethod;
+  /** Glob pattern. `*` = one segment, `**` = any number of segments. */
+  pattern: string;
+  /** Short reason surfaced in the error response. */
+  reason: string;
+}
+
+export const SENSITIVE_PATHS: readonly DenyEntry[] = [
+  {
+    pattern: "/api/users/*/apikeys",
+    reason:
+      "API key management is out of scope for the MCP server. Use the Octopus web portal.",
+  },
+  {
+    pattern: "/api/users/*/apikeys/**",
+    reason:
+      "API key management is out of scope for the MCP server. Use the Octopus web portal.",
+  },
+  {
+    method: "DELETE",
+    pattern: "/api/users/*",
+    reason:
+      "Deleting a user is irreversible and out of scope for the MCP server.",
+  },
+  {
+    method: "DELETE",
+    pattern: "/api/spaces/*",
+    reason:
+      "Deleting a Space is catastrophic and out of scope for the MCP server.",
+  },
+];
+
+export interface SensitiveCheckResult {
+  blocked: boolean;
+  reason?: string;
+}
+
+export function isSensitive(
+  method: HttpMethod,
+  path: string,
+  entries: readonly DenyEntry[] = SENSITIVE_PATHS,
+): SensitiveCheckResult {
+  for (const entry of entries) {
+    if (entry.method && entry.method !== method) continue;
+    if (pathMatchesGlob(path, entry.pattern)) {
+      return { blocked: true, reason: entry.reason };
+    }
+  }
+  return { blocked: false };
+}

--- a/src/helpers/validateExecutePath.ts
+++ b/src/helpers/validateExecutePath.ts
@@ -1,0 +1,69 @@
+/**
+ * Reject `execute` paths whose canonical form differs from what the allowlist
+ * and denylist would see, so a path like
+ *
+ *     /api/spaces/Spaces-1/../../users/me/apikeys
+ *
+ * cannot pass the `/api/spaces/**` allowlist while resolving to
+ * `/api/users/me/apikeys` on the server.
+ *
+ * The validator is deliberately conservative: anything that introduces
+ * ambiguity between the literal path string and what the HTTP client / Octopus
+ * routing will see — `..` segments, encoded slashes, backslashes, query
+ * strings, fragments, double slashes — is rejected outright. We do NOT try to
+ * normalise the path; rejecting unambiguously is safer than guessing the
+ * caller's intent.
+ *
+ * Query parameters belong in the `query` argument of the execute tool, not
+ * inside the `path` string — surfacing that as a reject prompts the agent to
+ * use the right field.
+ */
+
+export type PathValidation =
+  | { ok: true; path: string }
+  | { ok: false; reason: string };
+
+export function validateExecutePath(raw: string): PathValidation {
+  if (typeof raw !== "string" || raw.length === 0) {
+    return { ok: false, reason: "Path must be a non-empty string." };
+  }
+  if (!raw.startsWith("/")) {
+    return { ok: false, reason: "Path must start with '/'." };
+  }
+  if (raw.includes("\\")) {
+    return { ok: false, reason: "Path must not contain backslashes." };
+  }
+  if (raw.includes("?")) {
+    return {
+      ok: false,
+      reason:
+        "Path must not contain a query string. Pass query parameters via the `query` argument instead.",
+    };
+  }
+  if (raw.includes("#")) {
+    return { ok: false, reason: "Path must not contain a fragment ('#')." };
+  }
+  if (raw.includes("//")) {
+    return { ok: false, reason: "Path must not contain '//'." };
+  }
+  if (/%2f|%5c/i.test(raw)) {
+    return {
+      ok: false,
+      reason:
+        "Path must not contain percent-encoded slashes ('%2F') or backslashes ('%5C').",
+    };
+  }
+  // Reject any `..` segment — exact, leading, trailing, or surrounded by
+  // slashes. We do not attempt to resolve them.
+  const segments = raw.split("/");
+  for (const segment of segments) {
+    if (segment === "..") {
+      return {
+        ok: false,
+        reason:
+          "Path must not contain '..' segments. Provide the canonical path explicitly.",
+      };
+    }
+  }
+  return { ok: true, path: raw };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,10 @@ program
     "--no-read-only",
     "Disable read-only mode to enable write operations (default: read-only enabled)",
   )
+  .option(
+    "--allow-deletes",
+    "Permit DELETE-method requests through the execute tool. Requires --no-read-only. Default false.",
+  )
   .option("--log-level <level>", "Minimum log level (info, error)", "info")
   .option(
     "--log-file <path>",
@@ -86,8 +90,18 @@ Currently exposed resource families:
 - releases: 'octopus://spaces/{spaceName}/releases/{releaseId}'
 - tasks: 'octopus://spaces/{spaceName}/tasks/{taskId}' (metadata) and '/details' (structured ActivityLogs tree)
 - interruptions: 'octopus://spaces/{spaceName}/interruptions/{interruptionId}' (full Form definition with control types, Markdown instructions, button options like Abort/Proceed, and any submitted Form.Values). The find_interruptions tool returns slim summaries that point at this URI; dereference it to drill into a specific interruption.
+- catalog: 'octopus://api/llms.txt' is the markdown catalog of every Octopus REST endpoint (~300+ KB). 'octopus://api/capabilities' is the runtime introspection blob (server version, enabled toolsets, available tools, feature flags).
 
 There is intentionally NO 'octopus://.../tasks/{id}/log' resource. Activity logs can be multi-megabyte; an addressable resource would tempt you to fetch the entire body when you almost always want only the matching lines. To search a task log, call the 'grep_task_log' tool — its parameters mirror GNU grep (pattern, caseInsensitive, invertMatch, fixedString, beforeContext, afterContext, maxCount) and it returns matching lines with totalMatches count and optional context windows. For step hierarchy / categories / timing, fetch the /details resource instead.
+
+The same pattern applies to the API catalog: do NOT read 'octopus://api/llms.txt' directly because the body is large. Use the 'grep_llms_txt' tool — same GNU-grep parameter shape — to find the endpoints, methods, and request/response shapes you need.
+
+The 'execute' tool reaches Octopus REST endpoints not covered by curated tools. **Method gating is hard-coded server-side**, three tiers:
+- GET                    → read tier:   always allowed (subject to toolset allowlist + sensitive denylist).
+- POST / PUT / PATCH     → write tier:  requires --no-read-only AND user confirmation via elicitation.
+- DELETE                 → delete tier: requires --no-read-only AND --allow-deletes AND a stronger confirmation.
+
+The HTTP method enum IS the read/write/delete classifier — the runtime classifies based on the actual method, never on a flag the agent sets. Use grep_llms_txt to discover the right path + method before calling execute.
 
 More resource families will be added over time.
 `.trim();
@@ -103,7 +117,11 @@ const server = new McpServer(
   },
 );
 
-const toolsetConfig = createToolsetConfig(options.toolsets, options.readOnly);
+const toolsetConfig = createToolsetConfig(
+  options.toolsets,
+  options.readOnly,
+  options.allowDeletes,
+);
 registerTools(server, toolsetConfig);
 registerResources(server, toolsetConfig);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,19 @@ const toolsetConfig = createToolsetConfig(
   options.readOnly,
   options.allowDeletes,
 );
+
+// `--allow-deletes` only takes effect when write mode is also enabled.
+// Surface this on stderr at startup so an operator who turned the flag on
+// without remembering --no-read-only doesn't silently end up with DELETE
+// requests still blocked by the read-only gate.
+if (toolsetConfig.allowDeletes && toolsetConfig.readOnlyMode) {
+  process.stderr.write(
+    "WARNING: --allow-deletes was provided, but read-only mode is still " +
+      "enabled. DELETE requests through the execute tool remain blocked " +
+      "until --no-read-only is also set.\n",
+  );
+}
+
 registerTools(server, toolsetConfig);
 registerResources(server, toolsetConfig);
 

--- a/src/resources/catalog/__tests__/capabilities.test.ts
+++ b/src/resources/catalog/__tests__/capabilities.test.ts
@@ -183,4 +183,49 @@ describe("octopus://api/capabilities", () => {
 
     expect(cap.session.allowDeletes).toBe(true);
   });
+
+  it("flags execute as methodGated and reports its effective tiers per session", async () => {
+    getServerInformation.mockResolvedValue({
+      version: "2026.2.9373",
+      installationId: "abc-123",
+    });
+    get.mockResolvedValue({});
+
+    TOOL_REGISTRY.set(
+      "execute",
+      fakeRegistration("execute", "core", true),
+    );
+    TOOL_REGISTRY.set(
+      "list_spaces",
+      fakeRegistration("list_spaces", "core", true),
+    );
+
+    // Read-only mode: only the read tier is reachable.
+    setActiveToolsetConfig({ enabledToolsets: "all", readOnlyMode: true });
+    let cap = await buildCapabilities();
+    let executeEntry = cap.tools.find((t) => t.name === "execute")!;
+    expect(executeEntry.methodGated).toBe(true);
+    expect(executeEntry.tiersAvailable).toEqual(["read"]);
+
+    // Static read-only tools must NOT carry methodGated/tiersAvailable.
+    const listEntry = cap.tools.find((t) => t.name === "list_spaces")!;
+    expect(listEntry.methodGated).toBeUndefined();
+    expect(listEntry.tiersAvailable).toBeUndefined();
+
+    // --no-read-only without --allow-deletes: read + write reachable.
+    setActiveToolsetConfig({ enabledToolsets: "all", readOnlyMode: false });
+    cap = await buildCapabilities();
+    executeEntry = cap.tools.find((t) => t.name === "execute")!;
+    expect(executeEntry.tiersAvailable).toEqual(["read", "write"]);
+
+    // Both flags: all three tiers reachable.
+    setActiveToolsetConfig({
+      enabledToolsets: "all",
+      readOnlyMode: false,
+      allowDeletes: true,
+    });
+    cap = await buildCapabilities();
+    executeEntry = cap.tools.find((t) => t.name === "execute")!;
+    expect(executeEntry.tiersAvailable).toEqual(["read", "write", "delete"]);
+  });
 });

--- a/src/resources/catalog/__tests__/capabilities.test.ts
+++ b/src/resources/catalog/__tests__/capabilities.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const get = vi.fn();
+const getServerInformation = vi.fn();
+
+vi.mock("../../../helpers/getClientConfigurationFromEnvironment.js", () => ({
+  getClientConfigurationFromEnvironment: () => ({
+    instanceURL: "https://octopus.example",
+    apiKey: "API-TEST",
+  }),
+}));
+
+vi.mock("@octopusdeploy/api-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@octopusdeploy/api-client")>();
+  return {
+    ...actual,
+    Client: { create: vi.fn(async () => ({ get, getServerInformation })) },
+  };
+});
+
+import { buildCapabilities } from "../capabilities.js";
+import { setActiveToolsetConfig } from "../../../helpers/activeToolsetConfig.js";
+import {
+  TOOL_REGISTRY,
+  type ToolRegistration,
+} from "../../../types/toolConfig.js";
+
+function fakeRegistration(
+  toolName: string,
+  toolset: ToolRegistration["config"]["toolset"],
+  readOnly: boolean,
+  minimumOctopusVersion?: string,
+): ToolRegistration {
+  return {
+    toolName,
+    config: { toolset, readOnly },
+    registerFn: () => {},
+    minimumOctopusVersion,
+  };
+}
+
+describe("octopus://api/capabilities", () => {
+  beforeEach(() => {
+    get.mockReset();
+    getServerInformation.mockReset();
+    TOOL_REGISTRY.clear();
+    setActiveToolsetConfig({});
+  });
+
+  it("composes server info, session config, and the enabled tool list", async () => {
+    getServerInformation.mockResolvedValue({
+      version: "2026.2.9373",
+      installationId: "abc-123",
+    });
+    get.mockResolvedValue({ MultiTenancy: true, Kubernetes: true });
+
+    TOOL_REGISTRY.set(
+      "find_releases",
+      fakeRegistration("find_releases", "releases", true, "2024.1"),
+    );
+    TOOL_REGISTRY.set(
+      "list_spaces",
+      fakeRegistration("list_spaces", "core", true),
+    );
+    TOOL_REGISTRY.set(
+      "deploy_release",
+      fakeRegistration("deploy_release", "releases", false),
+    );
+    setActiveToolsetConfig({
+      enabledToolsets: ["releases"],
+      readOnlyMode: false,
+    });
+
+    const cap = await buildCapabilities();
+
+    expect(cap.server).toEqual({
+      version: "2026.2.9373",
+      installationId: "abc-123",
+    });
+    expect(cap.session.readOnlyMode).toBe(false);
+    expect(cap.session.allowDeletes).toBe(false);
+    expect(cap.session.enabledToolsets).toContain("releases");
+    expect(cap.session.enabledToolsets).toContain("core");
+    expect(cap.tools.map((t) => t.name).sort()).toEqual([
+      "deploy_release",
+      "find_releases",
+      "list_spaces",
+    ]);
+    expect(cap.tools.find((t) => t.name === "find_releases")).toMatchObject({
+      toolset: "releases",
+      readOnly: true,
+      minimumOctopusVersion: "2024.1",
+    });
+    expect(cap.featureFlags).toEqual({ MultiTenancy: true, Kubernetes: true });
+  });
+
+  it("hides write-tier tools when read-only mode is on", async () => {
+    getServerInformation.mockResolvedValue({
+      version: "2026.2.9373",
+      installationId: "abc-123",
+    });
+    get.mockResolvedValue({});
+
+    TOOL_REGISTRY.set(
+      "find_releases",
+      fakeRegistration("find_releases", "releases", true),
+    );
+    TOOL_REGISTRY.set(
+      "deploy_release",
+      fakeRegistration("deploy_release", "releases", false),
+    );
+    setActiveToolsetConfig({
+      enabledToolsets: ["releases"],
+      readOnlyMode: true,
+    });
+
+    const cap = await buildCapabilities();
+
+    expect(cap.tools.map((t) => t.name)).toEqual(["find_releases"]);
+  });
+
+  it("hides tools whose toolset is not enabled (core is always enabled)", async () => {
+    getServerInformation.mockResolvedValue({
+      version: "2026.2.9373",
+      installationId: "abc-123",
+    });
+    get.mockResolvedValue({});
+
+    TOOL_REGISTRY.set(
+      "list_spaces",
+      fakeRegistration("list_spaces", "core", true),
+    );
+    TOOL_REGISTRY.set(
+      "find_certificates",
+      fakeRegistration("find_certificates", "certificates", true),
+    );
+    setActiveToolsetConfig({
+      enabledToolsets: ["releases"],
+      readOnlyMode: true,
+    });
+
+    const cap = await buildCapabilities();
+
+    expect(cap.tools.map((t) => t.name)).toEqual(["list_spaces"]);
+    expect(cap.session.enabledToolsets).toContain("core");
+    expect(cap.session.enabledToolsets).toContain("releases");
+    expect(cap.session.enabledToolsets).not.toContain("certificates");
+  });
+
+  it("omits featureFlags when /api/serverstatus/extensions is unavailable", async () => {
+    getServerInformation.mockResolvedValue({
+      version: "2026.2.9373",
+      installationId: "abc-123",
+    });
+    get.mockRejectedValue(new Error("404 Not Found"));
+
+    setActiveToolsetConfig({
+      enabledToolsets: "all",
+      readOnlyMode: true,
+    });
+
+    const cap = await buildCapabilities();
+
+    expect("featureFlags" in cap).toBe(false);
+    expect(cap.server.version).toBe("2026.2.9373");
+  });
+
+  it("reflects allowDeletes from the active config", async () => {
+    getServerInformation.mockResolvedValue({
+      version: "2026.2.9373",
+      installationId: "abc-123",
+    });
+    get.mockResolvedValue({});
+
+    setActiveToolsetConfig({
+      enabledToolsets: "all",
+      readOnlyMode: false,
+      allowDeletes: true,
+    });
+
+    const cap = await buildCapabilities();
+
+    expect(cap.session.allowDeletes).toBe(true);
+  });
+});

--- a/src/resources/catalog/__tests__/llmsTxt.test.ts
+++ b/src/resources/catalog/__tests__/llmsTxt.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const getRaw = vi.fn();
+
+vi.mock("../../../helpers/getClientConfigurationFromEnvironment.js", () => ({
+  getClientConfigurationFromEnvironment: () => ({
+    instanceURL: "https://octopus.example",
+    apiKey: "API-TEST",
+  }),
+}));
+
+vi.mock("@octopusdeploy/api-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@octopusdeploy/api-client")>();
+  return {
+    ...actual,
+    Client: { create: vi.fn(async () => ({ getRaw })) },
+  };
+});
+
+import { fetchLlmsTxt, clearLlmsTxtCache } from "../llmsTxt.js";
+import "../llmsTxt.js"; // ensure descriptor registers
+import {
+  RESOURCE_REGISTRY,
+  type ResourceDescriptor,
+} from "../../../types/resourceConfig.js";
+
+function descriptorByName(name: string): ResourceDescriptor {
+  const descriptor = RESOURCE_REGISTRY.find((d) => d.name === name);
+  if (!descriptor) {
+    throw new Error(`Resource descriptor '${name}' is not registered.`);
+  }
+  return descriptor;
+}
+
+describe("octopus://api/llms.txt resource", () => {
+  beforeEach(() => {
+    getRaw.mockReset();
+    clearLlmsTxtCache();
+  });
+
+  it("fetches the body via Client.getRaw on the experimental llms.txt path", async () => {
+    getRaw.mockResolvedValue("# Octopus Deploy API\n\nbody");
+
+    const body = await fetchLlmsTxt();
+
+    expect(body).toBe("# Octopus Deploy API\n\nbody");
+    expect(getRaw).toHaveBeenCalledWith("~/api/experimental/llms.txt");
+  });
+
+  it("returns the cached body on subsequent calls within the TTL", async () => {
+    getRaw.mockResolvedValue("cached body");
+
+    await fetchLlmsTxt();
+    await fetchLlmsTxt();
+    await fetchLlmsTxt();
+
+    expect(getRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches after the cache is cleared (test seam for TTL expiry)", async () => {
+    getRaw.mockResolvedValue("first");
+    await fetchLlmsTxt();
+    expect(getRaw).toHaveBeenCalledTimes(1);
+
+    clearLlmsTxtCache();
+    getRaw.mockResolvedValue("second");
+    const second = await fetchLlmsTxt();
+
+    expect(second).toBe("second");
+    expect(getRaw).toHaveBeenCalledTimes(2);
+  });
+
+  it("registers a descriptor at octopus://api/llms.txt with text/markdown mime type", () => {
+    const descriptor = descriptorByName("catalog-llms-txt");
+
+    expect(descriptor.uriTemplate).toBe("octopus://api/llms.txt");
+    expect(descriptor.mimeType).toBe("text/markdown");
+    expect(descriptor.toolset).toBe("core");
+  });
+
+  it("descriptor.read returns the body verbatim with the markdown mime type", async () => {
+    getRaw.mockResolvedValue("# heading");
+    const descriptor = descriptorByName("catalog-llms-txt");
+
+    const payload = await descriptor.read({});
+
+    expect(payload).toEqual({ mimeType: "text/markdown", text: "# heading" });
+  });
+});

--- a/src/resources/catalog/capabilities.ts
+++ b/src/resources/catalog/capabilities.ts
@@ -7,12 +7,25 @@ import {
   type Toolset,
 } from "../../types/toolConfig.js";
 import { getActiveToolsetConfig } from "../../helpers/activeToolsetConfig.js";
+import { type MethodTier } from "../../helpers/methodTier.js";
 
 interface CapabilityToolEntry {
   name: string;
   toolset: Toolset;
   readOnly: boolean;
   minimumOctopusVersion?: string;
+  /**
+   * True for tools whose actual read/write/delete behaviour depends on
+   * arguments rather than a static tool-level flag. Currently set only on
+   * `execute`, where the HTTP method is the runtime classifier.
+   */
+  methodGated?: boolean;
+  /**
+   * Effective method tiers reachable through this tool in the *current*
+   * session. For `execute` this reflects --no-read-only and --allow-deletes;
+   * for static tools it is undefined (the `readOnly` flag is sufficient).
+   */
+  tiersAvailable?: MethodTier[];
 }
 
 interface Capabilities {
@@ -54,12 +67,24 @@ export async function buildCapabilities(): Promise<Capabilities> {
   for (const [name, registration] of TOOL_REGISTRY) {
     if (!enabledSet.has(registration.config.toolset)) continue;
     if (readOnlyMode && !registration.config.readOnly) continue;
-    tools.push({
+    const entry: CapabilityToolEntry = {
       name,
       toolset: registration.config.toolset,
       readOnly: registration.config.readOnly,
       minimumOctopusVersion: registration.minimumOctopusVersion,
-    });
+    };
+    // The execute tool registers as readOnly:true (so it survives the
+    // registration filter in read-only mode for its GET branch) but its
+    // actual behaviour is method-gated. Surface that explicitly so callers
+    // don't conclude execute is fully read-only.
+    if (name === "execute") {
+      entry.methodGated = true;
+      const tiers: MethodTier[] = ["read"];
+      if (!readOnlyMode) tiers.push("write");
+      if (!readOnlyMode && allowDeletes) tiers.push("delete");
+      entry.tiersAvailable = tiers;
+    }
+    tools.push(entry);
   }
   tools.sort((a, b) => a.name.localeCompare(b.name));
 

--- a/src/resources/catalog/capabilities.ts
+++ b/src/resources/catalog/capabilities.ts
@@ -1,0 +1,106 @@
+import { Client } from "@octopusdeploy/api-client";
+import { registerResourceDescriptor } from "../../types/resourceConfig.js";
+import { getClientConfigurationFromEnvironment } from "../../helpers/getClientConfigurationFromEnvironment.js";
+import {
+  TOOL_REGISTRY,
+  DEFAULT_TOOLSETS,
+  type Toolset,
+} from "../../types/toolConfig.js";
+import { getActiveToolsetConfig } from "../../helpers/activeToolsetConfig.js";
+
+interface CapabilityToolEntry {
+  name: string;
+  toolset: Toolset;
+  readOnly: boolean;
+  minimumOctopusVersion?: string;
+}
+
+interface Capabilities {
+  server: {
+    version: string;
+    installationId: string;
+  };
+  session: {
+    enabledToolsets: Toolset[];
+    readOnlyMode: boolean;
+    allowDeletes: boolean;
+  };
+  tools: CapabilityToolEntry[];
+  featureFlags?: unknown;
+}
+
+function resolveEnabledToolsets(): Toolset[] {
+  const config = getActiveToolsetConfig();
+  if (config.enabledToolsets === "all" || config.enabledToolsets == null) {
+    return DEFAULT_TOOLSETS;
+  }
+  return config.enabledToolsets;
+}
+
+export async function buildCapabilities(): Promise<Capabilities> {
+  const client = await Client.create(getClientConfigurationFromEnvironment());
+
+  const serverInfo = await client.getServerInformation();
+
+  const activeConfig = getActiveToolsetConfig();
+  const enabledToolsets = resolveEnabledToolsets();
+  const readOnlyMode = activeConfig.readOnlyMode ?? true;
+  const allowDeletes = activeConfig.allowDeletes ?? false;
+
+  const enabledSet = new Set<Toolset>(enabledToolsets);
+  enabledSet.add("core");
+
+  const tools: CapabilityToolEntry[] = [];
+  for (const [name, registration] of TOOL_REGISTRY) {
+    if (!enabledSet.has(registration.config.toolset)) continue;
+    if (readOnlyMode && !registration.config.readOnly) continue;
+    tools.push({
+      name,
+      toolset: registration.config.toolset,
+      readOnly: registration.config.readOnly,
+      minimumOctopusVersion: registration.minimumOctopusVersion,
+    });
+  }
+  tools.sort((a, b) => a.name.localeCompare(b.name));
+
+  let featureFlags: unknown;
+  try {
+    featureFlags = await client.get<unknown>("~/api/serverstatus/extensions");
+  } catch {
+    // The serverstatus/extensions endpoint isn't universally available across
+    // older Octopus versions. Omit feature flags rather than failing the whole
+    // capabilities read — server version is the high-value field.
+    featureFlags = undefined;
+  }
+
+  const capabilities: Capabilities = {
+    server: {
+      version: serverInfo.version,
+      installationId: serverInfo.installationId,
+    },
+    session: {
+      enabledToolsets: Array.from(enabledSet).sort() as Toolset[],
+      readOnlyMode,
+      allowDeletes,
+    },
+    tools,
+  };
+  if (featureFlags !== undefined) {
+    capabilities.featureFlags = featureFlags;
+  }
+  return capabilities;
+}
+
+registerResourceDescriptor({
+  name: "catalog-capabilities",
+  uriTemplate: "octopus://api/capabilities",
+  toolset: "core",
+  title: "Octopus MCP capabilities",
+  description:
+    "Server version, enabled toolsets, available tools, and Octopus feature flags for this MCP session. Use this to discover what's reachable before calling other tools.",
+  mimeType: "application/json",
+  read: async () => ({
+    mimeType: "application/json",
+    text: JSON.stringify(await buildCapabilities()),
+  }),
+});

--- a/src/resources/catalog/llmsTxt.ts
+++ b/src/resources/catalog/llmsTxt.ts
@@ -47,7 +47,7 @@ registerResourceDescriptor({
   toolset: "core",
   title: "Octopus API catalog (llms.txt)",
   description:
-    "Markdown catalog of every Octopus REST endpoint, including HTTP method, path, query params, and request/response types. Large (~300+ KB) — prefer the grep_llms_txt tool to search it instead of reading the whole body.",
+    "Markdown catalog of every Octopus REST endpoint, including HTTP method, path, query params, and request/response types. Large (~300+ KB) — prefer the grep_llms_txt tool to search it instead of reading the whole body. Requires Octopus Server 2026.2.3916 or later (the /api/experimental/llms.txt endpoint shipped in that release).",
   mimeType: "text/markdown",
   read: async () => ({
     mimeType: "text/markdown",

--- a/src/resources/catalog/llmsTxt.ts
+++ b/src/resources/catalog/llmsTxt.ts
@@ -1,0 +1,56 @@
+import { Client } from "@octopusdeploy/api-client";
+import { registerResourceDescriptor } from "../../types/resourceConfig.js";
+import { getClientConfigurationFromEnvironment } from "../../helpers/getClientConfigurationFromEnvironment.js";
+
+const LLMS_TXT_PATH = "~/api/experimental/llms.txt";
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface CacheEntry {
+  body: string;
+  fetchedAt: number;
+}
+
+// Module-scoped cache keyed on the configured Octopus server URL. llms.txt
+// only changes when Octopus itself ships a new version; refetching on every
+// resource read or every grep call would burn ~360 KB of bandwidth and add
+// latency to every catalog query.
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Fetch llms.txt for the configured Octopus server, with a 5-minute TTL cache.
+ * Exposed so grep_llms_txt can share the same cache.
+ */
+export async function fetchLlmsTxt(): Promise<string> {
+  const configuration = getClientConfigurationFromEnvironment();
+  const cacheKey = configuration.instanceURL ?? "(unknown)";
+  const now = Date.now();
+
+  const hit = cache.get(cacheKey);
+  if (hit && now - hit.fetchedAt < CACHE_TTL_MS) {
+    return hit.body;
+  }
+
+  const client = await Client.create(configuration);
+  const body = await client.getRaw(LLMS_TXT_PATH);
+  cache.set(cacheKey, { body, fetchedAt: now });
+  return body;
+}
+
+/** Test seam: clear the cache between tests. */
+export function clearLlmsTxtCache(): void {
+  cache.clear();
+}
+
+registerResourceDescriptor({
+  name: "catalog-llms-txt",
+  uriTemplate: "octopus://api/llms.txt",
+  toolset: "core",
+  title: "Octopus API catalog (llms.txt)",
+  description:
+    "Markdown catalog of every Octopus REST endpoint, including HTTP method, path, query params, and request/response types. Large (~300+ KB) — prefer the grep_llms_txt tool to search it instead of reading the whole body.",
+  mimeType: "text/markdown",
+  read: async () => ({
+    mimeType: "text/markdown",
+    text: await fetchLlmsTxt(),
+  }),
+});

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -6,12 +6,15 @@ import {
 } from "../types/toolConfig.js";
 import { RESOURCE_REGISTRY } from "../types/resourceConfig.js";
 import { flatten } from "./dispatch.js";
+import { setActiveToolsetConfig } from "../helpers/activeToolsetConfig.js";
 
 // Side-effect imports populate RESOURCE_REGISTRY.
 import "./release.js";
 import "./runbook.js";
 import "./task.js";
 import "./interruption.js";
+import "./catalog/llmsTxt.js";
+import "./catalog/capabilities.js";
 
 function isToolsetEnabled(toolset: Toolset, config: ToolsetConfig): boolean {
   const enabled: Toolset[] =
@@ -23,6 +26,7 @@ function isToolsetEnabled(toolset: Toolset, config: ToolsetConfig): boolean {
 }
 
 export function registerResources(server: McpServer, config: ToolsetConfig = {}): void {
+  setActiveToolsetConfig(config);
   for (const descriptor of RESOURCE_REGISTRY) {
     if (!isToolsetEnabled(descriptor.toolset, config)) continue;
 

--- a/src/tools/__tests__/execute.test.ts
+++ b/src/tools/__tests__/execute.test.ts
@@ -1,0 +1,381 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const dispatchRequest = vi.fn();
+const resolveUrl = vi.fn(
+  (path: string) => `https://octopus.example${path}`,
+);
+const elicitInput = vi.fn();
+const getClientCapabilities = vi.fn();
+
+vi.mock("../../helpers/getClientConfigurationFromEnvironment.js", () => ({
+  getClientConfigurationFromEnvironment: () => ({
+    instanceURL: "https://octopus.example",
+    apiKey: "API-TEST",
+  }),
+}));
+
+vi.mock("@octopusdeploy/api-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@octopusdeploy/api-client")>();
+  return {
+    ...actual,
+    Client: {
+      create: vi.fn(async () => ({ resolveUrl, dispatchRequest })),
+    },
+  };
+});
+
+import { registerExecuteTool } from "../execute.js";
+import { setActiveToolsetConfig } from "../../helpers/activeToolsetConfig.js";
+
+interface RegisteredTool {
+  config: {
+    title?: string;
+    description?: string;
+    annotations?: unknown;
+  };
+  handler: (args: Record<string, unknown>) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+}
+
+interface ServerStub {
+  registerTool: (
+    name: string,
+    config: RegisteredTool["config"],
+    handler: RegisteredTool["handler"],
+  ) => void;
+  server: {
+    getClientCapabilities: typeof getClientCapabilities;
+    elicitInput: typeof elicitInput;
+  };
+}
+
+function makeServerStub(): {
+  server: ServerStub;
+  registered: Map<string, RegisteredTool>;
+} {
+  const registered = new Map<string, RegisteredTool>();
+  return {
+    server: {
+      registerTool(name, config, handler) {
+        registered.set(name, { config, handler });
+      },
+      server: { getClientCapabilities, elicitInput },
+    },
+    registered,
+  };
+}
+
+function getHandler(): RegisteredTool["handler"] {
+  const { server, registered } = makeServerStub();
+  registerExecuteTool(server as never);
+  return registered.get("execute")!.handler;
+}
+
+function parseResponse(response: { content: Array<{ text: string }> }): {
+  success?: boolean;
+  reason?: string;
+  message?: string;
+  response?: unknown;
+} {
+  return JSON.parse(response.content[0].text);
+}
+
+describe("execute tool — read tier (GET)", () => {
+  beforeEach(() => {
+    dispatchRequest.mockReset();
+    resolveUrl.mockClear();
+    getClientCapabilities.mockReset();
+    elicitInput.mockReset();
+    setActiveToolsetConfig({
+      enabledToolsets: "all",
+      readOnlyMode: true,
+      allowDeletes: false,
+    });
+  });
+
+  it("allows GET in read-only mode without elicitation", async () => {
+    dispatchRequest.mockResolvedValue({ Items: [{ Name: "Default" }] });
+    const handler = getHandler();
+
+    const response = await handler({ method: "GET", path: "/api/spaces" });
+    const body = parseResponse(response);
+
+    expect(body.success).toBe(true);
+    expect(dispatchRequest).toHaveBeenCalledWith(
+      "GET",
+      "https://octopus.example/api/spaces",
+      null,
+    );
+    expect(elicitInput).not.toHaveBeenCalled();
+  });
+});
+
+describe("execute tool — write tier (POST/PUT/PATCH)", () => {
+  beforeEach(() => {
+    dispatchRequest.mockReset();
+    resolveUrl.mockClear();
+    getClientCapabilities.mockReset();
+    elicitInput.mockReset();
+  });
+
+  it("blocks POST in read-only mode with the readOnlyMode reason", async () => {
+    setActiveToolsetConfig({ enabledToolsets: "all", readOnlyMode: true });
+    const handler = getHandler();
+
+    const response = await handler({
+      method: "POST",
+      path: "/api/Spaces-1/projects",
+      body: { Name: "X" },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(parseResponse(response).reason).toBe("readOnlyMode");
+    expect(dispatchRequest).not.toHaveBeenCalled();
+  });
+
+  it("requests elicitation for POST in write mode and proceeds on accept", async () => {
+    setActiveToolsetConfig({ enabledToolsets: "all", readOnlyMode: false });
+    getClientCapabilities.mockReturnValue({ elicitation: {} });
+    elicitInput.mockResolvedValue({ action: "accept" });
+    dispatchRequest.mockResolvedValue({ Id: "Projects-99" });
+    const handler = getHandler();
+
+    const response = await handler({
+      method: "POST",
+      path: "/api/Spaces-1/projects",
+      body: { Name: "X" },
+    });
+
+    expect(elicitInput).toHaveBeenCalledOnce();
+    const elicMessage = elicitInput.mock.calls[0][0].message as string;
+    expect(elicMessage).toContain("POST /api/Spaces-1/projects");
+    expect(elicMessage).not.toContain("IRREVERSIBLE");
+    expect(parseResponse(response).success).toBe(true);
+  });
+
+  it("aborts POST when the user declines the elicitation", async () => {
+    setActiveToolsetConfig({ enabledToolsets: "all", readOnlyMode: false });
+    getClientCapabilities.mockReturnValue({ elicitation: {} });
+    elicitInput.mockResolvedValue({ action: "decline" });
+    const handler = getHandler();
+
+    const response = await handler({
+      method: "POST",
+      path: "/api/Spaces-1/projects",
+      body: { Name: "X" },
+    });
+
+    expect(dispatchRequest).not.toHaveBeenCalled();
+    expect(parseResponse(response).message).toMatch(/cancelled/i);
+  });
+
+  it("PATCH passes through the same write gate", async () => {
+    setActiveToolsetConfig({ enabledToolsets: "all", readOnlyMode: true });
+    const handler = getHandler();
+
+    const response = await handler({
+      method: "PATCH",
+      path: "/api/Spaces-1/projects/Projects-1",
+      body: {},
+    });
+
+    expect(response.isError).toBe(true);
+    expect(parseResponse(response).reason).toBe("readOnlyMode");
+  });
+});
+
+describe("execute tool — delete tier (DELETE)", () => {
+  beforeEach(() => {
+    dispatchRequest.mockReset();
+    resolveUrl.mockClear();
+    getClientCapabilities.mockReset();
+    elicitInput.mockReset();
+  });
+
+  it("blocks DELETE in read-only mode (mentions both flags)", async () => {
+    setActiveToolsetConfig({ enabledToolsets: "all", readOnlyMode: true });
+    const handler = getHandler();
+
+    const response = await handler({
+      method: "DELETE",
+      path: "/api/Spaces-1/runbookruns/RunbookRuns-1",
+    });
+
+    expect(response.isError).toBe(true);
+    const body = parseResponse(response);
+    expect(body.reason).toBe("readOnlyMode");
+    expect(body.message).toContain("--allow-deletes");
+  });
+
+  it("blocks DELETE when --no-read-only is set but --allow-deletes is not", async () => {
+    setActiveToolsetConfig({
+      enabledToolsets: "all",
+      readOnlyMode: false,
+      allowDeletes: false,
+    });
+    const handler = getHandler();
+
+    const response = await handler({
+      method: "DELETE",
+      path: "/api/Spaces-1/runbookruns/RunbookRuns-1",
+    });
+
+    expect(response.isError).toBe(true);
+    expect(parseResponse(response).reason).toBe("deletesNotAllowed");
+    expect(dispatchRequest).not.toHaveBeenCalled();
+  });
+
+  it("permits DELETE only when both flags are set, with a stronger elicitation message", async () => {
+    setActiveToolsetConfig({
+      enabledToolsets: "all",
+      readOnlyMode: false,
+      allowDeletes: true,
+    });
+    getClientCapabilities.mockReturnValue({ elicitation: {} });
+    elicitInput.mockResolvedValue({ action: "accept" });
+    dispatchRequest.mockResolvedValue({});
+    const handler = getHandler();
+
+    const response = await handler({
+      method: "DELETE",
+      path: "/api/Spaces-1/runbookruns/RunbookRuns-1",
+    });
+
+    expect(elicitInput).toHaveBeenCalledOnce();
+    const elicMessage = elicitInput.mock.calls[0][0].message as string;
+    expect(elicMessage).toContain("IRREVERSIBLE");
+    expect(parseResponse(response).success).toBe(true);
+  });
+
+  it("blocks catastrophic DELETEs even with both flags set (sensitive denylist)", async () => {
+    setActiveToolsetConfig({
+      enabledToolsets: "all",
+      readOnlyMode: false,
+      allowDeletes: true,
+    });
+    getClientCapabilities.mockReturnValue({ elicitation: {} });
+    const handler = getHandler();
+
+    const spaceDelete = await handler({
+      method: "DELETE",
+      path: "/api/spaces/Spaces-1",
+    });
+    expect(spaceDelete.isError).toBe(true);
+    expect(parseResponse(spaceDelete).reason).toBe("sensitivePath");
+
+    const userDelete = await handler({
+      method: "DELETE",
+      path: "/api/users/Users-1",
+    });
+    expect(userDelete.isError).toBe(true);
+    expect(parseResponse(userDelete).reason).toBe("sensitivePath");
+
+    expect(dispatchRequest).not.toHaveBeenCalled();
+    expect(elicitInput).not.toHaveBeenCalled();
+  });
+});
+
+describe("execute tool — sensitive denylist (always-on)", () => {
+  beforeEach(() => {
+    dispatchRequest.mockReset();
+    setActiveToolsetConfig({
+      enabledToolsets: "all",
+      readOnlyMode: false,
+      allowDeletes: true,
+    });
+  });
+
+  it("blocks API key endpoints regardless of method", async () => {
+    const handler = getHandler();
+
+    const get = await handler({
+      method: "GET",
+      path: "/api/users/me/apikeys",
+    });
+    expect(get.isError).toBe(true);
+    expect(parseResponse(get).reason).toBe("sensitivePath");
+
+    const post = await handler({
+      method: "POST",
+      path: "/api/users/Users-1/apikeys",
+      body: {},
+    });
+    expect(post.isError).toBe(true);
+    expect(parseResponse(post).reason).toBe("sensitivePath");
+
+    expect(dispatchRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe("execute tool — path allowlist by toolset", () => {
+  beforeEach(() => {
+    dispatchRequest.mockReset();
+    elicitInput.mockReset();
+    getClientCapabilities.mockReturnValue({ elicitation: {} });
+    elicitInput.mockResolvedValue({ action: "accept" });
+  });
+
+  it("blocks paths whose owning toolset is not enabled, naming the toolset", async () => {
+    setActiveToolsetConfig({
+      enabledToolsets: ["projects"],
+      readOnlyMode: true,
+    });
+    const handler = getHandler();
+
+    const response = await handler({
+      method: "GET",
+      path: "/api/Spaces-1/certificates",
+    });
+
+    expect(response.isError).toBe(true);
+    const body = parseResponse(response);
+    expect(body.reason).toBe("pathNotAllowed");
+    expect(body.message).toContain("certificates");
+    expect(dispatchRequest).not.toHaveBeenCalled();
+  });
+
+  it("permits paths owned by an enabled toolset", async () => {
+    setActiveToolsetConfig({
+      enabledToolsets: ["projects"],
+      readOnlyMode: true,
+    });
+    dispatchRequest.mockResolvedValue({});
+    const handler = getHandler();
+
+    const response = await handler({
+      method: "GET",
+      path: "/api/Spaces-1/projects",
+    });
+
+    expect(parseResponse(response).success).toBe(true);
+  });
+
+  it("core paths are reachable with no toolsets enabled", async () => {
+    setActiveToolsetConfig({
+      enabledToolsets: [],
+      readOnlyMode: true,
+    });
+    dispatchRequest.mockResolvedValue({});
+    const handler = getHandler();
+
+    const response = await handler({ method: "GET", path: "/api/spaces" });
+
+    expect(parseResponse(response).success).toBe(true);
+  });
+});
+
+describe("execute tool — registration metadata", () => {
+  it("registers as DESTRUCTIVE_WRITE so well-behaved clients confirm before run", () => {
+    const { server, registered } = makeServerStub();
+    registerExecuteTool(server as never);
+    const tool = registered.get("execute")!;
+
+    expect(tool.config.annotations).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: true,
+    });
+  });
+});

--- a/src/tools/__tests__/execute.test.ts
+++ b/src/tools/__tests__/execute.test.ts
@@ -367,6 +367,48 @@ describe("execute tool — path allowlist by toolset", () => {
   });
 });
 
+describe("execute tool — path validation (Gate 0)", () => {
+  beforeEach(() => {
+    dispatchRequest.mockReset();
+    elicitInput.mockReset();
+    setActiveToolsetConfig({
+      enabledToolsets: "all",
+      readOnlyMode: false,
+      allowDeletes: true,
+    });
+  });
+
+  it("rejects '..' traversal even when later gates would have allowed the canonical path", async () => {
+    // Codex-flagged bypass: this path passes the legacy /api/spaces/** core
+    // pattern but resolves to /api/users/me/apikeys server-side. Gate 0 must
+    // reject before sensitive denylist or allowlist run.
+    const handler = getHandler();
+    const response = await handler({
+      method: "GET",
+      path: "/api/spaces/Spaces-1/../../users/me/apikeys",
+    });
+    expect(response.isError).toBe(true);
+    expect(parseResponse(response).reason).toBe("invalidPath");
+    expect(dispatchRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects backslashes, query strings, fragments, and percent-encoded slashes", async () => {
+    const handler = getHandler();
+
+    for (const path of [
+      "/api/spaces\\..\\users",
+      "/api/spaces?take=10",
+      "/api/spaces#frag",
+      "/api/users%2Fme%2Fapikeys",
+    ]) {
+      const response = await handler({ method: "GET", path });
+      expect(response.isError).toBe(true);
+      expect(parseResponse(response).reason).toBe("invalidPath");
+    }
+    expect(dispatchRequest).not.toHaveBeenCalled();
+  });
+});
+
 describe("execute tool — registration metadata", () => {
   it("registers as DESTRUCTIVE_WRITE so well-behaved clients confirm before run", () => {
     const { server, registered } = makeServerStub();

--- a/src/tools/__tests__/grepLlmsTxt.test.ts
+++ b/src/tools/__tests__/grepLlmsTxt.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const fetchLlmsTxt = vi.fn();
+
+vi.mock("../../resources/catalog/llmsTxt.js", () => ({
+  fetchLlmsTxt: (...args: unknown[]) => fetchLlmsTxt(...args),
+}));
+
+import { registerGrepLlmsTxtTool } from "../grepLlmsTxt.js";
+
+interface RegisteredTool {
+  config: {
+    title?: string;
+    description?: string;
+    inputSchema?: unknown;
+    annotations?: unknown;
+  };
+  handler: (args: Record<string, unknown>) => Promise<{
+    content: Array<{ type: string; text: string }>;
+  }>;
+}
+
+function makeServerStub(): {
+  server: {
+    registerTool: (
+      name: string,
+      config: RegisteredTool["config"],
+      handler: RegisteredTool["handler"],
+    ) => void;
+  };
+  registered: Map<string, RegisteredTool>;
+} {
+  const registered = new Map<string, RegisteredTool>();
+  return {
+    server: {
+      registerTool(name, config, handler) {
+        registered.set(name, { config, handler });
+      },
+    },
+    registered,
+  };
+}
+
+const SAMPLE_LLMS = [
+  "# Octopus Deploy API",
+  "",
+  "## Endpoints",
+  "",
+  "### Releases",
+  "- `GET /releases` - list releases",
+  "- `POST /releases` - create release | Body: CreateReleaseCommand",
+  "- `DELETE /releases/{id}` - delete release",
+  "",
+  "### Channels",
+  "- `GET /channels` - list channels",
+  "- `POST /channels` - create channel | Body: CreateChannelCommand",
+  "- `DELETE /channels/{id}` - delete channel",
+  "",
+].join("\n");
+
+describe("grep_llms_txt tool handler", () => {
+  beforeEach(() => {
+    fetchLlmsTxt.mockReset();
+    fetchLlmsTxt.mockResolvedValue(SAMPLE_LLMS);
+  });
+
+  it("returns line-numbered matches for a literal pattern", async () => {
+    const { server, registered } = makeServerStub();
+    registerGrepLlmsTxtTool(server as never);
+    const tool = registered.get("grep_llms_txt")!;
+
+    const response = await tool.handler({ pattern: "POST /" });
+
+    const result = JSON.parse(response.content[0].text) as {
+      totalMatches: number;
+      matches: Array<{ lineNumber: number; line: string }>;
+      catalogResourceUri: string;
+      pattern: string;
+    };
+
+    expect(result.totalMatches).toBe(2);
+    expect(result.matches.map((m) => m.line)).toEqual([
+      "- `POST /releases` - create release | Body: CreateReleaseCommand",
+      "- `POST /channels` - create channel | Body: CreateChannelCommand",
+    ]);
+    expect(result.catalogResourceUri).toBe("octopus://api/llms.txt");
+    expect(result.pattern).toBe("POST /");
+  });
+
+  it("supports section-heading discovery for the agent", async () => {
+    const { server, registered } = makeServerStub();
+    registerGrepLlmsTxtTool(server as never);
+    const tool = registered.get("grep_llms_txt")!;
+
+    const response = await tool.handler({ pattern: "^### " });
+    const result = JSON.parse(response.content[0].text) as {
+      matches: Array<{ line: string }>;
+    };
+
+    expect(result.matches.map((m) => m.line)).toEqual([
+      "### Releases",
+      "### Channels",
+    ]);
+  });
+
+  it("reports truncated:true and the true totalMatches when maxCount is exceeded", async () => {
+    const { server, registered } = makeServerStub();
+    registerGrepLlmsTxtTool(server as never);
+    const tool = registered.get("grep_llms_txt")!;
+
+    // 4 lines start with `- \``; cap at 2.
+    const response = await tool.handler({
+      pattern: "^- `",
+      maxCount: 2,
+    });
+    const result = JSON.parse(response.content[0].text) as {
+      totalMatches: number;
+      returnedMatches: number;
+      truncated: boolean;
+    };
+
+    expect(result.totalMatches).toBe(6);
+    expect(result.returnedMatches).toBe(2);
+    expect(result.truncated).toBe(true);
+  });
+
+  it("calls fetchLlmsTxt exactly once per invocation (cache lives in the resource module)", async () => {
+    const { server, registered } = makeServerStub();
+    registerGrepLlmsTxtTool(server as never);
+    const tool = registered.get("grep_llms_txt")!;
+
+    await tool.handler({ pattern: "GET" });
+
+    expect(fetchLlmsTxt).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers as read-only", () => {
+    const { server, registered } = makeServerStub();
+    registerGrepLlmsTxtTool(server as never);
+    const tool = registered.get("grep_llms_txt")!;
+
+    expect(tool.config.annotations).toMatchObject({ readOnlyHint: true });
+  });
+});

--- a/src/tools/execute.ts
+++ b/src/tools/execute.ts
@@ -12,6 +12,7 @@ import {
 } from "../helpers/methodTier.js";
 import { isSensitive } from "../helpers/sensitivePathDenylist.js";
 import { matchPath, findOwningToolset } from "../helpers/pathAllowlist.js";
+import { validateExecutePath } from "../helpers/validateExecutePath.js";
 import {
   requireConfirmation,
   unconfirmedResponse,
@@ -34,6 +35,7 @@ interface ExecuteParams {
 interface ExecuteErrorResponse {
   success: false;
   reason:
+    | "invalidPath"
     | "readOnlyMode"
     | "deletesNotAllowed"
     | "sensitivePath"
@@ -181,7 +183,7 @@ The HTTP method enum is the gate. The tool will not honour any 'isRead' flag the
 
 **Other gates** (in order):
   1. Sensitive denylist: API key endpoints and catastrophic deletes (DELETE /api/users/{id}, DELETE /api/spaces/{id}) are always blocked.
-  2. Path allowlist by enabled toolset: paths only resolve if their owning toolset is enabled. Disabling 'audit' makes /api/events* unreachable even on GET.
+  2. Path allowlist by enabled toolset: paths only resolve if their owning toolset is enabled. Disabling a toolset (e.g. 'certificates') makes its endpoints unreachable even on GET.
   3. Elicitation on every non-GET, with a stronger message for DELETE.
 
 Discover endpoints with grep_llms_txt. Use octopus://api/capabilities to see which toolsets are enabled and whether write/delete modes are on.`,
@@ -190,12 +192,27 @@ Discover endpoints with grep_llms_txt. Use octopus://api/capabilities to see whi
     },
     async (args) => {
       const params = args as ExecuteParams;
-      const { method, path, query, body, asCsv } = params;
+      const { method, path: rawPath, query, body, asCsv } = params;
       const tier = classifyMethod(method);
-      const audit = startAudit({ method, tier, path });
+      const audit = startAudit({ method, tier, path: rawPath });
       const config = getActiveToolsetConfig();
       const readOnlyMode = config.readOnlyMode ?? true;
       const allowDeletes = config.allowDeletes ?? false;
+
+      // Gate 0: path canonicalization. Reject paths that can mean different
+      // things to the allowlist matcher and the HTTP client (`..` traversal,
+      // encoded slashes, query strings, fragments, backslashes). Runs FIRST
+      // so a traversal attempt cannot pass any later gate.
+      const validation = validateExecutePath(rawPath);
+      if (!validation.ok) {
+        audit("blocked", "invalidPath");
+        return errorResponse({
+          success: false,
+          reason: "invalidPath",
+          message: `Invalid path: ${validation.reason}`,
+        });
+      }
+      const path = validation.path;
 
       // Gate 1: sensitive denylist (always-on, applies regardless of mode).
       const sensitive = isSensitive(method, path);

--- a/src/tools/execute.ts
+++ b/src/tools/execute.ts
@@ -1,0 +1,340 @@
+import { Client } from "@octopusdeploy/api-client";
+import { z } from "zod";
+import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerToolDefinition } from "../types/toolConfig.js";
+import { DESTRUCTIVE_WRITE_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
+import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
+import {
+  HTTP_METHODS,
+  classifyMethod,
+  type HttpMethod,
+  type MethodTier,
+} from "../helpers/methodTier.js";
+import { isSensitive } from "../helpers/sensitivePathDenylist.js";
+import { matchPath, findOwningToolset } from "../helpers/pathAllowlist.js";
+import {
+  requireConfirmation,
+  unconfirmedResponse,
+} from "../helpers/requireConfirmation.js";
+import { getActiveToolsetConfig } from "../helpers/activeToolsetConfig.js";
+import {
+  DEFAULT_TOOLSETS,
+  type Toolset,
+} from "../types/toolConfig.js";
+
+interface ExecuteParams {
+  method: HttpMethod;
+  path: string;
+  query?: Record<string, string>;
+  body?: unknown;
+  asCsv?: boolean;
+  confirm?: boolean;
+}
+
+interface ExecuteErrorResponse {
+  success: false;
+  reason:
+    | "readOnlyMode"
+    | "deletesNotAllowed"
+    | "sensitivePath"
+    | "pathNotAllowed";
+  message: string;
+  details?: unknown;
+}
+
+function errorResponse(payload: ExecuteErrorResponse) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+    isError: true,
+  };
+}
+
+function summariseBody(body: unknown): string {
+  if (body == null) return "(no body)";
+  if (typeof body === "string") {
+    return body.length > 200 ? `${body.slice(0, 200)}…` : body;
+  }
+  try {
+    const json = JSON.stringify(body);
+    if (json.length <= 400) return json;
+    return `${json.slice(0, 400)}… (${json.length} bytes total)`;
+  } catch {
+    return "(unserialisable body)";
+  }
+}
+
+type AuditOutcome = "ok" | "error" | "blocked" | "cancelled";
+
+interface AuditCall {
+  method: HttpMethod;
+  tier: MethodTier;
+  path: string;
+}
+
+/**
+ * Build a one-shot audit emitter scoped to a single execute call. Captures
+ * the start time so callers only state outcome + reason — no need to repeat
+ * method/tier/path/durationMs at every gate. Stub on stderr; replace with the
+ * structured emitter from AIF-357 once it lands.
+ */
+function startAudit(call: AuditCall): (
+  outcome: AuditOutcome,
+  reason?: string,
+) => void {
+  const startedAt = Date.now();
+  return (outcome, reason) => {
+    process.stderr.write(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        tool: "execute",
+        ...call,
+        outcome,
+        ...(reason !== undefined ? { reason } : {}),
+        durationMs: Date.now() - startedAt,
+      }) + "\n",
+    );
+  };
+}
+
+function resolveEnabledToolsets(): readonly Toolset[] {
+  const config = getActiveToolsetConfig();
+  if (config.enabledToolsets === "all" || config.enabledToolsets == null) {
+    return DEFAULT_TOOLSETS;
+  }
+  return config.enabledToolsets;
+}
+
+interface DispatchableClient {
+  resolveUrl: (path: string, args?: unknown) => string;
+  dispatchRequest: (
+    method: string,
+    url: string,
+    body?: unknown,
+  ) => Promise<unknown>;
+}
+
+async function dispatchExecute(
+  client: Client,
+  method: HttpMethod,
+  path: string,
+  query: Record<string, string> | undefined,
+  body: unknown,
+): Promise<unknown> {
+  const dispatchable = client as unknown as DispatchableClient;
+  const url = dispatchable.resolveUrl(path, query);
+  return dispatchable.dispatchRequest(method, url, body ?? null);
+}
+
+const inputSchema = {
+  method: z
+    .enum(HTTP_METHODS as unknown as [HttpMethod, ...HttpMethod[]])
+    .describe(
+      "HTTP method. The method itself is the read/write/delete classifier — GET is read-only, POST/PUT/PATCH require --no-read-only, DELETE additionally requires --allow-deletes. The agent cannot bypass this by lying about intent.",
+    ),
+  path: z
+    .string()
+    .min(1)
+    .describe(
+      "Path under the configured Octopus server, e.g. '/api/spaces/Spaces-1/feeds' or '/api/Spaces-1/projects'. Discover paths via grep_llms_txt.",
+    ),
+  query: z
+    .record(z.string())
+    .optional()
+    .describe("Optional query-string parameters as a flat object."),
+  body: z
+    .unknown()
+    .optional()
+    .describe("Optional request body for POST/PUT/PATCH calls."),
+  asCsv: z
+    .boolean()
+    .optional()
+    .describe(
+      "If true, request 'text/csv' for tabular GET responses. The Octopus API honours this for endpoints that support CSV output.",
+    ),
+  confirm: z
+    .boolean()
+    .optional()
+    .describe(
+      "Required only when the MCP client does not support elicitation. Set to true to confirm a non-GET call; otherwise the tool aborts.",
+    ),
+};
+
+export function registerExecuteTool(server: McpServer) {
+  server.registerTool(
+    "execute",
+    {
+      title: "Execute an Octopus REST request (backstop)",
+      description: `Reach Octopus REST endpoints not covered by the curated tools. Use this only after grep_llms_txt has shown you the right method and path.
+
+**Method gating is hard-coded server-side, three tiers:**
+
+  - GET    → read tier: always allowed (subject to toolset allowlist + sensitive denylist).
+  - POST/PUT/PATCH → write tier: requires --no-read-only AND user confirmation via elicitation.
+  - DELETE → delete tier: requires --no-read-only AND --allow-deletes AND a stronger user confirmation.
+
+The HTTP method enum is the gate. The tool will not honour any 'isRead' flag the agent invents — the runtime classifies based on the actual method.
+
+**Other gates** (in order):
+  1. Sensitive denylist: API key endpoints and catastrophic deletes (DELETE /api/users/{id}, DELETE /api/spaces/{id}) are always blocked.
+  2. Path allowlist by enabled toolset: paths only resolve if their owning toolset is enabled. Disabling 'audit' makes /api/events* unreachable even on GET.
+  3. Elicitation on every non-GET, with a stronger message for DELETE.
+
+Discover endpoints with grep_llms_txt. Use octopus://api/capabilities to see which toolsets are enabled and whether write/delete modes are on.`,
+      inputSchema,
+      annotations: DESTRUCTIVE_WRITE_TOOL_ANNOTATIONS,
+    },
+    async (args) => {
+      const params = args as ExecuteParams;
+      const { method, path, query, body, asCsv } = params;
+      const tier = classifyMethod(method);
+      const audit = startAudit({ method, tier, path });
+      const config = getActiveToolsetConfig();
+      const readOnlyMode = config.readOnlyMode ?? true;
+      const allowDeletes = config.allowDeletes ?? false;
+
+      // Gate 1: sensitive denylist (always-on, applies regardless of mode).
+      const sensitive = isSensitive(method, path);
+      if (sensitive.blocked) {
+        audit("blocked", "sensitivePath");
+        return errorResponse({
+          success: false,
+          reason: "sensitivePath",
+          message: `Path '${path}' is on the sensitive denylist and cannot be reached via execute. ${sensitive.reason ?? ""}`.trim(),
+        });
+      }
+
+      // Gate 2: tier-based mode gate.
+      if (tier === "write" && readOnlyMode) {
+        audit("blocked", "readOnlyMode");
+        return errorResponse({
+          success: false,
+          reason: "readOnlyMode",
+          message:
+            "This server is in read-only mode. Restart with --no-read-only to enable write requests through the execute tool.",
+        });
+      }
+      if (tier === "delete") {
+        if (readOnlyMode) {
+          audit("blocked", "readOnlyMode");
+          return errorResponse({
+            success: false,
+            reason: "readOnlyMode",
+            message:
+              "This server is in read-only mode. Restart with --no-read-only AND --allow-deletes to permit DELETE requests through the execute tool.",
+          });
+        }
+        if (!allowDeletes) {
+          audit("blocked", "deletesNotAllowed");
+          return errorResponse({
+            success: false,
+            reason: "deletesNotAllowed",
+            message:
+              "DELETE requests are not permitted. Restart with --allow-deletes (in addition to --no-read-only) to enable them. This is a deliberate two-flag opt-in for irreversible operations.",
+          });
+        }
+      }
+
+      // Gate 3: path allowlist by enabled toolset.
+      const enabledToolsets = resolveEnabledToolsets();
+      const allowed = matchPath(path, enabledToolsets);
+      if (!allowed.matched) {
+        const owner = findOwningToolset(path);
+        audit("blocked", "pathNotAllowed");
+        return errorResponse({
+          success: false,
+          reason: "pathNotAllowed",
+          message: owner
+            ? `Path '${path}' belongs to the '${owner}' toolset which is not enabled in this session. Enable it via --toolsets to reach this endpoint.`
+            : `Path '${path}' is not on the execute allowlist for any toolset. If this is a legitimate Octopus endpoint not yet covered, file an issue against the MCP server.`,
+        });
+      }
+
+      // Gate 4: elicitation on every non-GET.
+      if (tier !== "read") {
+        const isDelete = tier === "delete";
+        const message = isDelete
+          ? `IRREVERSIBLE delete operation. Confirm carefully.\n\n${method} ${path}\nQuery: ${JSON.stringify(query ?? {})}\nBody: ${summariseBody(body)}`
+          : `${method} ${path}\nQuery: ${JSON.stringify(query ?? {})}\nBody: ${summariseBody(body)}`;
+        const confirmation = await requireConfirmation(server, {
+          message,
+          fallbackConfirm: params.confirm,
+        });
+        if (!confirmation.confirmed) {
+          audit("cancelled", confirmation.reason);
+          return unconfirmedResponse(confirmation, {
+            action: isDelete ? "deletion" : "API call",
+          });
+        }
+      }
+
+      // All gates passed. Dispatch.
+      try {
+        const client = await Client.create(
+          getClientConfigurationFromEnvironment(),
+        );
+        const requestQuery = asCsv
+          ? { ...(query ?? {}), format: "csv" }
+          : query;
+        const result = await dispatchExecute(
+          client,
+          method,
+          path,
+          requestQuery,
+          body,
+        );
+        audit("ok");
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                success: true,
+                method,
+                path,
+                tier,
+                response: result,
+              }),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        audit("error", message);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: false,
+                  reason: "octopusError",
+                  method,
+                  path,
+                  tier,
+                  message,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+registerToolDefinition({
+  toolName: "execute",
+  // readOnly: true so the tool is registered even in --read-only mode (where
+  // only its GET branch is reachable). Method-tier gating inside the handler
+  // enforces the actual write/delete policy at runtime.
+  config: { toolset: "core", readOnly: true },
+  registerFn: registerExecuteTool,
+});

--- a/src/tools/grepLlmsTxt.ts
+++ b/src/tools/grepLlmsTxt.ts
@@ -1,0 +1,140 @@
+import { z } from "zod";
+import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
+import {
+  grepLines,
+  MAX_CONTEXT,
+  MAX_COUNT_HARD_CAP,
+  type GrepLinesParams,
+  type GrepMatch,
+} from "../helpers/grepLines.js";
+import { fetchLlmsTxt } from "../resources/catalog/llmsTxt.js";
+
+export interface GrepLlmsTxtResult {
+  pattern: string;
+  totalLines: number;
+  totalMatches: number;
+  returnedMatches: number;
+  truncated: boolean;
+  matches: GrepMatch[];
+  catalogResourceUri: string;
+}
+
+const inputSchema = {
+  pattern: z
+    .string()
+    .min(1)
+    .describe(
+      "Regex (default) or literal substring (when fixedString=true). Tested against each line of llms.txt independently — same model as `grep`.",
+    ),
+  caseInsensitive: z
+    .boolean()
+    .default(false)
+    .describe("Equivalent to grep -i. Default false."),
+  invertMatch: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Equivalent to grep -v: return lines that do NOT match. Default false.",
+    ),
+  fixedString: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Equivalent to grep -F: treat pattern as a literal substring, not a regex. Use this when grepping for text containing regex metacharacters. Default false.",
+    ),
+  beforeContext: z
+    .number()
+    .int()
+    .min(0)
+    .max(MAX_CONTEXT)
+    .default(0)
+    .describe(
+      `Equivalent to grep -B: lines of preceding context to include with each match. Capped at ${MAX_CONTEXT}.`,
+    ),
+  afterContext: z
+    .number()
+    .int()
+    .min(0)
+    .max(MAX_CONTEXT)
+    .default(0)
+    .describe(
+      `Equivalent to grep -A: lines of trailing context to include with each match. Capped at ${MAX_CONTEXT}.`,
+    ),
+  maxCount: z
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_COUNT_HARD_CAP)
+    .default(100)
+    .describe(
+      `Equivalent to grep -m: stop returning matches after this many. totalMatches in the response still reflects the true count across the whole file. Hard cap ${MAX_COUNT_HARD_CAP}.`,
+    ),
+};
+
+export function registerGrepLlmsTxtTool(server: McpServer) {
+  server.registerTool(
+    "grep_llms_txt",
+    {
+      title: "Grep the Octopus API catalog (llms.txt)",
+      description: `Search the Octopus API catalog at octopus://api/llms.txt with grep-style semantics. The catalog is large (~300+ KB) — call this rather than reading the resource body directly.
+
+llms.txt is structured as:
+- Authentication and Space Selection sections (top of file)
+- Endpoints section: one '### {Category}' heading per resource family (Accounts, ActionTemplates, Channels, Releases, …) and one bullet per endpoint of the form
+    \`- \\\`METHOD /path\\\` - description | Prefixes (pick one): /{spaceId}, /spaces/{spaceIdentifier} | ?queryParams → ReturnType\`
+- Steps section: deployment step types (Octopus.* ActionType) and their configurable property keys.
+
+Useful patterns:
+- 'POST /releases'   — find write endpoints under a resource family
+- 'DELETE '          — enumerate delete endpoints
+- '### Channels'     — jump to a section heading
+- 'Body: Create.*Command' — find endpoints that take a Create command body
+
+Parameter conventions mirror GNU grep:
+- pattern (regex by default; set fixedString:true for literal text)
+- caseInsensitive   (-i)
+- invertMatch       (-v)
+- fixedString       (-F)
+- beforeContext     (-B)
+- afterContext      (-A)
+- maxCount          (-m)
+
+Response: totalMatches (true count across the whole file), totalLines, the matched lines with 1-indexed lineNumber, optional before/after context arrays, and catalogResourceUri for the structured fall-through.`,
+      inputSchema,
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
+    },
+    async (args) => {
+      const params = args as GrepLinesParams;
+
+      const body = await fetchLlmsTxt();
+      const { totalLines, totalMatches, matches } = grepLines(body, params);
+
+      const result: GrepLlmsTxtResult = {
+        pattern: params.pattern,
+        totalLines,
+        totalMatches,
+        returnedMatches: matches.length,
+        truncated: totalMatches > matches.length,
+        matches,
+        catalogResourceUri: "octopus://api/llms.txt",
+      };
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result),
+          },
+        ],
+      };
+    },
+  );
+}
+
+registerToolDefinition({
+  toolName: "grep_llms_txt",
+  config: { toolset: "core", readOnly: true },
+  registerFn: registerGrepLlmsTxtTool,
+});

--- a/src/tools/grepLlmsTxt.ts
+++ b/src/tools/grepLlmsTxt.ts
@@ -137,4 +137,6 @@ registerToolDefinition({
   toolName: "grep_llms_txt",
   config: { toolset: "core", readOnly: true },
   registerFn: registerGrepLlmsTxtTool,
+  // The /api/experimental/llms.txt endpoint shipped in Octopus 2026.2.3916.
+  minimumOctopusVersion: "2026.2.3916",
 });

--- a/src/tools/grepTaskLog.ts
+++ b/src/tools/grepTaskLog.ts
@@ -9,6 +9,12 @@ import {
   handleOctopusApiError,
   ENTITY_PREFIXES,
 } from "../helpers/errorHandling.js";
+import {
+  grepLines,
+  MAX_CONTEXT,
+  MAX_COUNT_HARD_CAP,
+  type GrepMatch,
+} from "../helpers/grepLines.js";
 
 export interface GrepTaskLogParams {
   spaceName: string;
@@ -20,18 +26,6 @@ export interface GrepTaskLogParams {
   beforeContext?: number;
   afterContext?: number;
   maxCount?: number;
-}
-
-export interface ContextLine {
-  lineNumber: number;
-  line: string;
-}
-
-export interface GrepMatch {
-  lineNumber: number;
-  line: string;
-  before?: ContextLine[];
-  after?: ContextLine[];
 }
 
 export interface GrepTaskLogResult {
@@ -48,97 +42,6 @@ export interface GrepTaskLogResult {
    * grep can express (e.g. step hierarchy, category filtering, timing).
    */
   taskDetailsResourceUri: string;
-}
-
-const MAX_CONTEXT = 50;
-const MAX_COUNT_HARD_CAP = 500;
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function compilePattern(
-  pattern: string,
-  caseInsensitive: boolean,
-  fixedString: boolean,
-): RegExp {
-  const source = fixedString ? escapeRegExp(pattern) : pattern;
-  const flags = caseInsensitive ? "i" : "";
-  try {
-    return new RegExp(source, flags);
-  } catch (error) {
-    throw new Error(
-      `Invalid pattern: ${error instanceof Error ? error.message : String(error)}. ` +
-        "Set fixedString:true to treat the pattern as a literal substring instead of a regex.",
-    );
-  }
-}
-
-/**
- * Pure-function grep implementation. Exported for unit tests.
- *
- * Mirrors GNU grep's line-by-line semantics: each line is tested independently,
- * matching lines are emitted with optional symmetric context windows. Overlapping
- * context between adjacent matches is NOT deduplicated — each match carries its
- * own complete context window so the consumer can reason about each match in
- * isolation. This is a deliberate departure from GNU grep's `--`-separated
- * output but it is the right shape for a JSON tool response.
- */
-export function grepLines(
-  rawLog: string,
-  params: GrepTaskLogParams,
-): { totalLines: number; totalMatches: number; matches: GrepMatch[] } {
-  const {
-    pattern,
-    caseInsensitive = false,
-    invertMatch = false,
-    fixedString = false,
-    beforeContext = 0,
-    afterContext = 0,
-    maxCount = 100,
-  } = params;
-
-  const lines = rawLog.split("\n");
-  // Drop the trailing empty element produced by a final newline.
-  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
-
-  const regex = compilePattern(pattern, caseInsensitive, fixedString);
-
-  const matches: GrepMatch[] = [];
-  let totalMatches = 0;
-
-  for (let i = 0; i < lines.length; i++) {
-    const isMatch = regex.test(lines[i]) !== invertMatch;
-    if (!isMatch) continue;
-
-    totalMatches++;
-    if (matches.length >= maxCount) continue;
-
-    const match: GrepMatch = {
-      lineNumber: i + 1,
-      line: lines[i],
-    };
-
-    if (beforeContext > 0) {
-      const start = Math.max(0, i - beforeContext);
-      match.before = lines.slice(start, i).map((line, idx) => ({
-        lineNumber: start + idx + 1,
-        line,
-      }));
-    }
-
-    if (afterContext > 0) {
-      const end = Math.min(lines.length, i + 1 + afterContext);
-      match.after = lines.slice(i + 1, end).map((line, idx) => ({
-        lineNumber: i + 2 + idx,
-        line,
-      }));
-    }
-
-    matches.push(match);
-  }
-
-  return { totalLines: lines.length, totalMatches, matches };
 }
 
 const inputSchema = {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -38,6 +38,12 @@ import "./runRunbook.js";
 // Task log search
 import "./grepTaskLog.js";
 
+// API catalog search (llms.txt)
+import "./grepLlmsTxt.js";
+
+// REST backstop with hard read/write/delete gating
+import "./execute.js";
+
 // Resource backstop for clients without native MCP resource support
 import "./readResource.js";
 function isToolEnabled(

--- a/src/types/toolConfig.ts
+++ b/src/types/toolConfig.ts
@@ -23,6 +23,12 @@ export interface ToolConfig {
 export interface ToolsetConfig {
   enabledToolsets?: Toolset[] | "all";
   readOnlyMode?: boolean;
+  /**
+   * Permit DELETE-method requests through the `execute` backstop tool.
+   * Requires `readOnlyMode: false` to take effect — the read-only gate runs
+   * first. Default false (no DELETE allowed even with --no-read-only).
+   */
+  allowDeletes?: boolean;
 }
 
 export interface ToolRegistration {

--- a/src/utils/parseConfig.ts
+++ b/src/utils/parseConfig.ts
@@ -20,10 +20,12 @@ export function parseToolsets(toolsetsArg: string | undefined): Toolset[] | "all
 
 export function createToolsetConfig(
   toolsetsArg: string | undefined,
-  readOnlyArg: boolean | undefined
+  readOnlyArg: boolean | undefined,
+  allowDeletesArg?: boolean | undefined,
 ): ToolsetConfig {
   return {
     enabledToolsets: parseToolsets(toolsetsArg),
-    readOnlyMode: readOnlyArg ?? true // Default to read-only mode
+    readOnlyMode: readOnlyArg ?? true, // Default to read-only mode
+    allowDeletes: allowDeletesArg ?? false, // Default deny all DELETEs
   };
 }


### PR DESCRIPTION
## Summary

Closes [AIF-359](https://linear.app/octopus/issue/AIF-359) and [AIF-377](https://linear.app/octopus/issue/AIF-377). Two phases shipped together as one progressive change.

**Phase 1 — catalog resource + grep tool**
- `octopus://api/llms.txt` resource with a 5-min in-memory TTL cache, shared with the grep tool so a search doesn't trigger a re-fetch.
- `octopus://api/capabilities` resource: server version, enabled toolsets, available tools, feature flags.
- `grep_llms_txt` tool — same GNU-grep parameter shape as `grep_task_log`. The catalog body is ~360 KB; reading it directly is what we're avoiding.
- Lifted `grepLines` into `src/helpers/grepLines.ts` so both grep tools share one implementation. Old test migrated alongside.

**Phase 2 — execute backstop with hard read/write/delete tiering**
- HTTP method is the authoritative classifier — never an `isWrite` flag the LLM sets. `classifyMethod(method)` maps GET → `read`, POST/PUT/PATCH → `write`, DELETE → `delete`.
- New `--allow-deletes` CLI flag + `ToolsetConfig.allowDeletes`. DELETE requires **both** `--no-read-only` AND `--allow-deletes` — a deliberate two-flag opt-in for irreversible operations.
- Six gates inside `execute.ts`, in order: sensitive denylist → tier mode gate → path allowlist by enabled toolset → elicitation (DELETE gets a stronger "IRREVERSIBLE" message) → dispatch → audit-on-stderr.
- Sensitive denylist covers API-key endpoints and catastrophic deletes (DELETE on `/api/users/{id}` and `/api/spaces/{id}`); enforced even with both flags on.
- Glob engine in `pathGlob.ts` is shared between allowlist and denylist. Only `*` and `**` are wildcards; every other character is escaped, so denylist patterns can't be turned into regex injection.

**Refactors landed in the same change**
- Shared `compilePathGlob` between allow/deny (was duplicated).
- `activeToolsetConfig` lives under `src/helpers/` (was misplaced under `resources/catalog/` since execute also reads it).
- `grepLines` test migrated to `src/helpers/__tests__/`; `grepTaskLog.ts` no longer needs to re-export it.
- Audit emission in `execute.ts` uses a closure that captures the start time, so each gate's emit is one line (`audit(\"blocked\", \"readOnlyMode\")`) instead of six.

## Out of scope (intentionally — Phase 3)
[AIF-360](https://linear.app/octopus/issue/AIF-360) (JSON schema resources for write payloads) and [AIF-367](https://linear.app/octopus/issue/AIF-367) (`describe` tool) are deferred. Once this lands, agents have `grep_llms_txt` to discover endpoint shapes — adequate as a stopgap.

## Test plan
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run --exclude '**/*.integration.test.ts'` — 137 unit tests pass (60+ new)
- [ ] Live smoke test against `https://main.testoctopus.app`: read `octopus://api/capabilities`, run `grep_llms_txt` for `'POST /releases'`, exercise the read tier of `execute` with `GET /api/spaces`, verify the readOnlyMode gate blocks a POST, verify the deletesNotAllowed gate blocks a DELETE under `--no-read-only` only.
- [ ] Pre-existing integration test failures (11) for `findInterruptions`/`listTenants` are unchanged — they fail on a missing 'Octopus Server' test space, unrelated to this work.

## Coordination
The Linear tickets [AIF-359](https://linear.app/octopus/issue/AIF-359) and [AIF-377](https://linear.app/octopus/issue/AIF-377) describe the work as written before the three-tier DELETE design was confirmed. Worth updating the ticket bodies post-merge to reflect:
- AIF-359: scope grew to include `grep_llms_txt` and the `grepLines` helper extraction (~250 LOC, was ~150).
- AIF-377: three-tier read/write/delete classification with the new `--allow-deletes` flag, plus catastrophic-delete entries on the sensitive denylist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)