### PR TITLE
feat: Add find_feature_toggles and update_feature_toggle tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Available toolsets:
 - **certificates** - Certificate operations
 - **accounts** - Account operations
 - **interruptions** - Manual intervention and approval operations
+- **featureToggles** - Inspect and lightly adjust customer feature toggles
 - **context** - Authenticated user and project context (current user, Git branches)
 
 #### Read-Only Mode
@@ -206,6 +207,7 @@ The server runs in read-only mode by default for security. Most tools are read-o
 - `create_release` - Create new releases
 - `deploy_release` - Deploy releases to environments and tenants
 - `run_runbook` - Run a runbook against one or more environments (and optional tenants)
+- `update_feature_toggle` - Adjust per-environment state and rollout percentages on an existing feature toggle
 
 Write tools are gated by an MCP elicitation prompt: clients that support elicitation will be asked to confirm before the call proceeds. Clients without elicitation support must pass `confirm: true` in the tool arguments — otherwise the tool aborts with an error. Set `OCTOPUS_SKIP_ELICITATION=true` to bypass the gate entirely (intended for unattended automation).
 
@@ -338,6 +340,14 @@ There is intentionally no `/log` resource: activity logs can be multi-megabyte, 
 ### Interruptions
 - `find_interruptions`: Find pending or historical interruptions (manual interventions, approvals, guided-failure prompts) in a space, optionally filtered by task, project, environment, regarding document, responsibility, or pending state. Returns slim summaries; dereference the `octopus://spaces/{spaceName}/interruptions/{interruptionId}` resource for the full Form definition (control types, Markdown instructions, button options, submitted Form.Values).
 
+### Feature Toggles
+- `find_feature_toggles`: List customer feature toggles in a project. Each summary includes per-environment state (`isEnabled`, `rolloutPercentage`, `clientRolloutPercentage`) plus a `resourceUri` so "where is X turned on" is answerable from the list response.
+- `update_feature_toggle`: Adjust an existing toggle. Narrow surface — flip an environment on/off, change rollout percentages, or update the toggle-level description / default state. Internally fetches the current toggle, applies your patches in memory, and PUTs the merged body, so unmentioned environments and unmentioned fields are preserved. Patches that reference an environment not already configured on the toggle are rejected.
+
+The full toggle body (description, tenants, segments, minimum versions) is available as an MCP Resource at `octopus://spaces/{spaceName}/projects/{projectId}/featuretoggles/{slug}`. Rollout group bodies are addressable at `octopus://spaces/{spaceName}/projects/{projectId}/rolloutgroups/{rolloutGroupId}` for read-only inspection.
+
+**Out of scope (use the Octopus UI):** creating new feature toggles, deleting toggles, renaming or retagging, attaching/detaching rollout groups, tenant targeting, segments, minimum-version filters, and rollout-group / SDK client-identifier management.
+
 ### Additional Tools
 - `get_deployment_process`: Get deployment process by ID for projects or releases
 - `get_variables`: Get all project variables and library variable set variables for a project (supports config-as-code projects via `gitRef`)
@@ -357,6 +367,8 @@ The Octopus MCP Server includes both read and write operations. Important securi
 When read-only mode is disabled (`--no-read-only`), the following write operations are available:
 - **Creating releases**: Can create new releases for projects
 - **Deploying releases**: Can trigger deployments to environments (including production)
+- **Running runbooks**: Can execute runbooks against environments and tenants
+- **Updating feature toggles**: Can flip per-environment state and change rollout percentages on existing toggles
 
 **Critical Security Measures:**
 1. **Least Privilege**: Use API keys with the minimum permissions needed for your use case

--- a/src/helpers/__tests__/pathAllowlist.test.ts
+++ b/src/helpers/__tests__/pathAllowlist.test.ts
@@ -108,4 +108,56 @@ describe("findOwningToolset", () => {
   it("returns undefined for paths no toolset claims", () => {
     expect(findOwningToolset("/api/something/never/registered")).toBeUndefined();
   });
+
+  it("picks the most-specific (most literal segments) toolset when multiple claim a path", () => {
+    // Both `projects` (/api/*/projects/**) and `featureToggles`
+    // (/api/*/projects/*/featuretoggles) match this path. The latter wins
+    // because its pattern has more literal segments.
+    expect(
+      findOwningToolset(
+        "/api/Spaces-1/projects/Projects-123/featuretoggles",
+      ),
+    ).toBe("featureToggles");
+    expect(
+      findOwningToolset(
+        "/api/Spaces-1/projects/Projects-123/featuretoggles/checkout-redesign",
+      ),
+    ).toBe("featureToggles");
+  });
+});
+
+describe("matchPath — kill-switch behaviour for nested toolsets", () => {
+  it("denies a feature toggle path when only the broader `projects` toolset is enabled", () => {
+    // Without most-specific-match-wins, `projects` would shadow
+    // `featureToggles` and the path would slip through. With it, disabling
+    // `featureToggles` is a real kill switch — the curated tools AND the
+    // execute backstop both lose access.
+    expect(
+      matchPath(
+        "/api/Spaces-1/projects/Projects-123/featuretoggles",
+        ["projects"],
+      ),
+    ).toMatchObject({ matched: false, toolset: "featureToggles" });
+  });
+
+  it("allows a feature toggle path when `featureToggles` is enabled", () => {
+    expect(
+      matchPath(
+        "/api/Spaces-1/projects/Projects-123/featuretoggles",
+        ["featureToggles"],
+      ),
+    ).toMatchObject({ matched: true, toolset: "featureToggles" });
+  });
+
+  it("still allows non-feature-toggle project sub-paths through `projects`", () => {
+    // Regression check: tightening the algorithm must not break paths
+    // owned solely by `projects` (e.g. deployment processes nested under
+    // projects).
+    expect(
+      matchPath(
+        "/api/Spaces-1/projects/Projects-1/deploymentprocesses/snapshot",
+        ["projects"],
+      ),
+    ).toMatchObject({ matched: true, toolset: "projects" });
+  });
 });

--- a/src/helpers/pathAllowlist.ts
+++ b/src/helpers/pathAllowlist.ts
@@ -111,8 +111,12 @@ const TOOLSET_PATH_PATTERNS: Record<Toolset, readonly string[]> = {
   featureToggles: [
     // Customer feature toggles are project-scoped, so the paths nest under
     // /projects/*/featuretoggles rather than directly under the space. The
-    // `projects` toolset's `/api/*/projects/**` wildcard would also match
-    // these — that's fine, both attributions allow the request through.
+    // `projects` toolset's `/api/*/projects/**` wildcard ALSO matches these,
+    // but the most-specific-match-wins logic in matchPath/findOwningToolset
+    // (below) attributes them to `featureToggles` because these patterns
+    // have more literal segments. So disabling `featureToggles` is a real
+    // kill switch — the path becomes unreachable through `execute` even
+    // when `projects` is still enabled.
     "/api/*/projects/*/featuretoggles",
     "/api/*/projects/*/featuretoggles/**",
     "/api/spaces/*/projects/*/featuretoggles",
@@ -120,46 +124,66 @@ const TOOLSET_PATH_PATTERNS: Record<Toolset, readonly string[]> = {
   ],
 };
 
+// Specificity = count of literal (non-wildcard) segments in the pattern.
+// "/api/<wildcard>/projects/<doublewildcard>" has 2 literal segments
+// (api, projects). "/api/<wildcard>/projects/<wildcard>/featuretoggles"
+// has 3 (api, projects, featuretoggles). The more-literal pattern wins
+// ownership when multiple toolsets claim the same path. This makes nested
+// concerns (feature toggles under projects, kubernetes live-status under
+// machines) into real kill switches rather than honour-system overlays.
+function patternSpecificity(pattern: string): number {
+  return pattern
+    .split("/")
+    .filter((seg) => seg.length > 0 && seg !== "*" && seg !== "**").length;
+}
+
 export interface AllowlistMatch {
   matched: boolean;
   toolset?: Toolset;
 }
 
 /**
- * Check whether `path` falls under the allowlist for any currently-enabled
- * toolset. The `core` toolset is implicitly always enabled; callers do not
- * need to include it in `enabledToolsets`.
+ * Find which toolset owns `path`. Most-specific-match-wins: if multiple
+ * toolsets have patterns matching the path, the toolset whose pattern has
+ * more literal segments wins ownership. Returns undefined if no toolset
+ * claims the path at all.
+ *
+ * This is the basis for both `matchPath` (allowlist enforcement) and the
+ * "which toolset do I need to enable?" error message in `execute`.
+ */
+export function findOwningToolset(path: string): Toolset | undefined {
+  let best: { toolset: Toolset; specificity: number } | null = null;
+  for (const toolset of Object.keys(TOOLSET_PATH_PATTERNS) as Toolset[]) {
+    for (const pattern of TOOLSET_PATH_PATTERNS[toolset]) {
+      if (!pathMatchesGlob(path, pattern)) continue;
+      const specificity = patternSpecificity(pattern);
+      if (!best || specificity > best.specificity) {
+        best = { toolset, specificity };
+      }
+    }
+  }
+  return best?.toolset;
+}
+
+/**
+ * Check whether `path` falls under the allowlist given which toolsets are
+ * currently enabled. The `core` toolset is implicitly always enabled.
+ *
+ * The owning toolset (most-specific match) must be the one enabled — a
+ * less-specific toolset whose wildcard happens to also match cannot shadow
+ * a disabled, more-specific owner. So `featureToggles` paths require the
+ * `featureToggles` toolset, even when `projects` (whose `/projects/**`
+ * wildcard also matches) is enabled.
  */
 export function matchPath(
   path: string,
   enabledToolsets: readonly Toolset[],
 ): AllowlistMatch {
-  const candidates: Toolset[] = [
-    "core",
-    ...enabledToolsets.filter((t) => t !== "core"),
-  ];
-  for (const toolset of candidates) {
-    for (const pattern of TOOLSET_PATH_PATTERNS[toolset]) {
-      if (pathMatchesGlob(path, pattern)) {
-        return { matched: true, toolset };
-      }
-    }
-  }
-  return { matched: false };
-}
+  const owner = findOwningToolset(path);
+  if (!owner) return { matched: false };
 
-/**
- * Find which toolset would have allowed `path` if it were enabled. Used to
- * produce a helpful error response that names the toolset the user needs to
- * turn on.
- */
-export function findOwningToolset(path: string): Toolset | undefined {
-  for (const toolset of Object.keys(TOOLSET_PATH_PATTERNS) as Toolset[]) {
-    for (const pattern of TOOLSET_PATH_PATTERNS[toolset]) {
-      if (pathMatchesGlob(path, pattern)) {
-        return toolset;
-      }
-    }
-  }
-  return undefined;
+  const isEnabled = owner === "core" || enabledToolsets.includes(owner);
+  return isEnabled
+    ? { matched: true, toolset: owner }
+    : { matched: false, toolset: owner };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ const configuredServerUrl =
 const SERVER_INSTRUCTIONS = `
 The official Octopus Deploy MCP server, currently connected to: ${configuredServerUrl}
 
-Tools are grouped into toolsets (core, releases, deployments, tasks, tenants, kubernetes, machines, certificates, accounts, interruptions) and you can filter them via --toolsets. Writes are gated behind --no-read-only.
+Tools are grouped into toolsets (core, releases, deployments, tasks, tenants, kubernetes, machines, certificates, accounts, interruptions, featureToggles) and you can filter them via --toolsets. Writes are gated behind --no-read-only.
 
 Resource URIs and how to dereference them:
 - Many tools return slim summaries plus an 'octopus://...' URI in fields like 'resourceUri' or 'taskResourceUri' instead of inlining heavy payloads (release notes, packaged versions, structured task activity trees, etc.). To fetch the full body, dereference the URI.
@@ -86,6 +86,8 @@ Currently exposed resource families:
 - releases: 'octopus://spaces/{spaceName}/releases/{releaseId}'
 - tasks: 'octopus://spaces/{spaceName}/tasks/{taskId}' (metadata) and '/details' (structured ActivityLogs tree)
 - interruptions: 'octopus://spaces/{spaceName}/interruptions/{interruptionId}' (full Form definition with control types, Markdown instructions, button options like Abort/Proceed, and any submitted Form.Values). The find_interruptions tool returns slim summaries that point at this URI; dereference it to drill into a specific interruption.
+- feature toggles: 'octopus://spaces/{spaceName}/projects/{projectId}/featuretoggles/{slug}' (full toggle body — per-environment configuration including tenant lists, segments, minimum versions). The find_feature_toggles slim summaries omit those fields and point at this URI.
+- rollout groups: 'octopus://spaces/{spaceName}/projects/{projectId}/rolloutgroups/{rolloutGroupId}' (read-only — this server doesn't expose rollout group writes; use the Octopus UI for those).
 
 There is intentionally NO 'octopus://.../tasks/{id}/log' resource. Activity logs can be multi-megabyte; an addressable resource would tempt you to fetch the entire body when you almost always want only the matching lines. To search a task log, call the 'grep_task_log' tool — its parameters mirror GNU grep (pattern, caseInsensitive, invertMatch, fixedString, beforeContext, afterContext, maxCount) and it returns matching lines with totalMatches count and optional context windows. For step hierarchy / categories / timing, fetch the /details resource instead.
 

--- a/src/resources/__tests__/dispatch.test.ts
+++ b/src/resources/__tests__/dispatch.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { dispatchOctopusUri } from "../dispatch.js";
 import {
   RESOURCE_REGISTRY,
   registerResourceDescriptor,
   type ResourceDescriptor,
 } from "../../types/resourceConfig.js";
+import { setActiveToolsetConfig } from "../../helpers/activeToolsetConfig.js";
 
 /**
  * Tests target the dispatch + registry contract in isolation:
@@ -129,5 +130,67 @@ describe("dispatchOctopusUri", () => {
     expect(await dispatchOctopusUri("https://example.com/foo")).toBeNull();
     expect(await dispatchOctopusUri("not-a-uri")).toBeNull();
     expect(descriptor.read).not.toHaveBeenCalled();
+  });
+
+  describe("toolset filtering", () => {
+    afterEach(() => {
+      // Reset to "all enabled" so other test files aren't affected by leaked state.
+      setActiveToolsetConfig({});
+    });
+
+    it("skips a descriptor whose toolset is not enabled, so read_resource cannot bypass --toolsets filtering by URI guess", async () => {
+      const featureToggleDescriptor = makeDescriptor({
+        name: "featureToggle",
+        toolset: "featureToggles",
+        uriTemplate:
+          "octopus://spaces/{spaceName}/projects/{projectId}/featuretoggles/{slug}",
+      });
+      registerResourceDescriptor(featureToggleDescriptor);
+
+      // Session enabled `projects` but NOT `featureToggles`.
+      setActiveToolsetConfig({ enabledToolsets: ["projects"] });
+
+      const payload = await dispatchOctopusUri(
+        "octopus://spaces/Default/projects/Projects-123/featuretoggles/checkout",
+      );
+
+      expect(payload).toBeNull();
+      expect(featureToggleDescriptor.read).not.toHaveBeenCalled();
+    });
+
+    it("invokes a descriptor when its toolset IS enabled", async () => {
+      const featureToggleDescriptor = makeDescriptor({
+        name: "featureToggle",
+        toolset: "featureToggles",
+        uriTemplate:
+          "octopus://spaces/{spaceName}/projects/{projectId}/featuretoggles/{slug}",
+      });
+      registerResourceDescriptor(featureToggleDescriptor);
+
+      setActiveToolsetConfig({ enabledToolsets: ["featureToggles"] });
+
+      const payload = await dispatchOctopusUri(
+        "octopus://spaces/Default/projects/Projects-123/featuretoggles/checkout",
+      );
+
+      expect(payload).not.toBeNull();
+      expect(featureToggleDescriptor.read).toHaveBeenCalledTimes(1);
+    });
+
+    it("always allows core descriptors regardless of enabledToolsets", async () => {
+      const coreDescriptor = makeDescriptor({
+        name: "catalog",
+        toolset: "core",
+        uriTemplate: "octopus://api/llms.txt",
+      });
+      registerResourceDescriptor(coreDescriptor);
+
+      // No toolsets enabled; core should still resolve.
+      setActiveToolsetConfig({ enabledToolsets: [] });
+
+      const payload = await dispatchOctopusUri("octopus://api/llms.txt");
+      expect(payload).not.toBeNull();
+      expect(coreDescriptor.read).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/resources/__tests__/featureToggle.test.ts
+++ b/src/resources/__tests__/featureToggle.test.ts
@@ -26,39 +26,11 @@ import {
 } from "../../types/resourceConfig.js";
 import "../featureToggle.js";
 
-function descriptorByName(name: string): ResourceDescriptor {
-  const descriptor = RESOURCE_REGISTRY.find((d) => d.name === name);
-  if (!descriptor) {
-    throw new Error(`Resource descriptor '${name}' is not registered.`);
-  }
-  return descriptor;
+function descriptor(name: string): ResourceDescriptor {
+  const d = RESOURCE_REGISTRY.find((r) => r.name === name);
+  if (!d) throw new Error(`Resource '${name}' not registered.`);
+  return d;
 }
-
-const sampleToggle = {
-  Id: "FeatureToggles-9",
-  SpaceId: "Spaces-1",
-  ProjectId: "Projects-123",
-  Name: "checkout-redesign",
-  Slug: "checkout-redesign",
-  DefaultIsEnabled: false,
-  Description: "Rolls out the new checkout flow.",
-  Environments: [
-    {
-      DeploymentEnvironmentId: "Environments-7",
-      IsEnabled: true,
-      RolloutPercentage: 25,
-      ClientRolloutPercentage: 50,
-      TenantIds: ["Tenants-42"],
-      Segments: [{ Key: "browser", Value: "Chrome" }],
-      MinimumVersion: "1.4.0",
-    },
-  ],
-  Tags: ["release-rings/beta"],
-  RolloutGroupId: "RolloutGroups-3",
-  Links: {
-    Self: "/api/Spaces-1/projects/Projects-123/featuretoggles/checkout-redesign",
-  },
-};
 
 describe("featureToggle resource", () => {
   beforeEach(() => {
@@ -67,25 +39,34 @@ describe("featureToggle resource", () => {
     resolveSpaceId.mockResolvedValue("Spaces-1");
   });
 
-  it("returns the full toggle body and strips Links", async () => {
-    get.mockResolvedValueOnce(sampleToggle);
+  it("fetches the toggle by slug at the project-scoped path and strips the HATEOAS Links bag", async () => {
+    get.mockResolvedValueOnce({
+      Id: "FeatureToggles-9",
+      Slug: "checkout-redesign",
+      Environments: [
+        {
+          DeploymentEnvironmentId: "Environments-7",
+          Segments: [{ Key: "browser", Value: "Chrome" }],
+          MinimumVersion: "1.4.0",
+        },
+      ],
+      RolloutGroupId: "RolloutGroups-3",
+      Links: { Self: "/api/Spaces-1/projects/Projects-123/featuretoggles/checkout-redesign" },
+    });
 
-    const payload = await descriptorByName("featureToggle").read({
+    const payload = await descriptor("featureToggle").read({
       spaceName: "Default",
       projectId: "Projects-123",
       slug: "checkout-redesign",
     });
 
-    expect(payload.mimeType).toBe("application/json");
     const body = JSON.parse(payload.text);
-
     expect(body.Links).toBeUndefined();
-    expect(body.Slug).toBe("checkout-redesign");
+    // Heavy fields the slim summary omits are present in the resource.
     expect(body.Environments[0].Segments).toEqual([
       { Key: "browser", Value: "Chrome" },
     ]);
     expect(body.Environments[0].MinimumVersion).toBe("1.4.0");
-    expect(body.RolloutGroupId).toBe("RolloutGroups-3");
 
     expect(get).toHaveBeenCalledWith(
       "~/api/{spaceId}/projects/{projectId}/featuretoggles/{slug}",
@@ -95,17 +76,5 @@ describe("featureToggle resource", () => {
         slug: "checkout-redesign",
       },
     );
-  });
-
-  it("translates 404 from the api-client into a friendly error", async () => {
-    get.mockRejectedValueOnce(new Error("Resource not found (404)"));
-
-    await expect(
-      descriptorByName("featureToggle").read({
-        spaceName: "Default",
-        projectId: "Projects-123",
-        slug: "missing",
-      }),
-    ).rejects.toThrow(/not found in space 'Default'/);
   });
 });

--- a/src/resources/__tests__/featureToggle.test.ts
+++ b/src/resources/__tests__/featureToggle.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const get = vi.fn();
+const resolveSpaceId = vi.fn();
+
+vi.mock("../../helpers/getClientConfigurationFromEnvironment.js", () => ({
+  getClientConfigurationFromEnvironment: () => ({
+    instanceURL: "https://octopus.example",
+    apiKey: "API-TEST",
+  }),
+}));
+
+vi.mock("@octopusdeploy/api-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@octopusdeploy/api-client")>();
+  return {
+    ...actual,
+    Client: { create: vi.fn(async () => ({ get })) },
+    resolveSpaceId: (...args: unknown[]) => resolveSpaceId(...args),
+  };
+});
+
+import {
+  RESOURCE_REGISTRY,
+  type ResourceDescriptor,
+} from "../../types/resourceConfig.js";
+import "../featureToggle.js";
+
+function descriptorByName(name: string): ResourceDescriptor {
+  const descriptor = RESOURCE_REGISTRY.find((d) => d.name === name);
+  if (!descriptor) {
+    throw new Error(`Resource descriptor '${name}' is not registered.`);
+  }
+  return descriptor;
+}
+
+const sampleToggle = {
+  Id: "FeatureToggles-9",
+  SpaceId: "Spaces-1",
+  ProjectId: "Projects-123",
+  Name: "checkout-redesign",
+  Slug: "checkout-redesign",
+  DefaultIsEnabled: false,
+  Description: "Rolls out the new checkout flow.",
+  Environments: [
+    {
+      DeploymentEnvironmentId: "Environments-7",
+      IsEnabled: true,
+      RolloutPercentage: 25,
+      ClientRolloutPercentage: 50,
+      TenantIds: ["Tenants-42"],
+      Segments: [{ Key: "browser", Value: "Chrome" }],
+      MinimumVersion: "1.4.0",
+    },
+  ],
+  Tags: ["release-rings/beta"],
+  RolloutGroupId: "RolloutGroups-3",
+  Links: {
+    Self: "/api/Spaces-1/projects/Projects-123/featuretoggles/checkout-redesign",
+  },
+};
+
+describe("featureToggle resource", () => {
+  beforeEach(() => {
+    get.mockReset();
+    resolveSpaceId.mockReset();
+    resolveSpaceId.mockResolvedValue("Spaces-1");
+  });
+
+  it("returns the full toggle body and strips Links", async () => {
+    get.mockResolvedValueOnce(sampleToggle);
+
+    const payload = await descriptorByName("featureToggle").read({
+      spaceName: "Default",
+      projectId: "Projects-123",
+      slug: "checkout-redesign",
+    });
+
+    expect(payload.mimeType).toBe("application/json");
+    const body = JSON.parse(payload.text);
+
+    expect(body.Links).toBeUndefined();
+    expect(body.Slug).toBe("checkout-redesign");
+    expect(body.Environments[0].Segments).toEqual([
+      { Key: "browser", Value: "Chrome" },
+    ]);
+    expect(body.Environments[0].MinimumVersion).toBe("1.4.0");
+    expect(body.RolloutGroupId).toBe("RolloutGroups-3");
+
+    expect(get).toHaveBeenCalledWith(
+      "~/api/{spaceId}/projects/{projectId}/featuretoggles/{slug}",
+      {
+        spaceId: "Spaces-1",
+        projectId: "Projects-123",
+        slug: "checkout-redesign",
+      },
+    );
+  });
+
+  it("translates 404 from the api-client into a friendly error", async () => {
+    get.mockRejectedValueOnce(new Error("Resource not found (404)"));
+
+    await expect(
+      descriptorByName("featureToggle").read({
+        spaceName: "Default",
+        projectId: "Projects-123",
+        slug: "missing",
+      }),
+    ).rejects.toThrow(/not found in space 'Default'/);
+  });
+});

--- a/src/resources/__tests__/rolloutGroup.test.ts
+++ b/src/resources/__tests__/rolloutGroup.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const get = vi.fn();
+const resolveSpaceId = vi.fn();
+
+vi.mock("../../helpers/getClientConfigurationFromEnvironment.js", () => ({
+  getClientConfigurationFromEnvironment: () => ({
+    instanceURL: "https://octopus.example",
+    apiKey: "API-TEST",
+  }),
+}));
+
+vi.mock("@octopusdeploy/api-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@octopusdeploy/api-client")>();
+  return {
+    ...actual,
+    Client: { create: vi.fn(async () => ({ get })) },
+    resolveSpaceId: (...args: unknown[]) => resolveSpaceId(...args),
+  };
+});
+
+import {
+  RESOURCE_REGISTRY,
+  type ResourceDescriptor,
+} from "../../types/resourceConfig.js";
+import "../rolloutGroup.js";
+
+function descriptorByName(name: string): ResourceDescriptor {
+  const descriptor = RESOURCE_REGISTRY.find((d) => d.name === name);
+  if (!descriptor) {
+    throw new Error(`Resource descriptor '${name}' is not registered.`);
+  }
+  return descriptor;
+}
+
+const sampleGroup = {
+  Id: "RolloutGroups-3",
+  SpaceId: "Spaces-1",
+  ProjectId: "Projects-123",
+  Name: "Beta wave",
+  FeatureToggleUsages: [
+    { Id: "FeatureToggles-9", Name: "checkout-redesign" },
+    { Id: "FeatureToggles-12", Name: "search-overhaul" },
+  ],
+  Links: {
+    Self: "/api/Spaces-1/projects/Projects-123/featuretoggles/rollout-groups/RolloutGroups-3",
+  },
+};
+
+describe("rolloutGroup resource", () => {
+  beforeEach(() => {
+    get.mockReset();
+    resolveSpaceId.mockReset();
+    resolveSpaceId.mockResolvedValue("Spaces-1");
+  });
+
+  it("returns the full group body with Links stripped", async () => {
+    get.mockResolvedValueOnce(sampleGroup);
+
+    const payload = await descriptorByName("rolloutGroup").read({
+      spaceName: "Default",
+      projectId: "Projects-123",
+      rolloutGroupId: "RolloutGroups-3",
+    });
+
+    expect(payload.mimeType).toBe("application/json");
+    const body = JSON.parse(payload.text);
+
+    expect(body.Links).toBeUndefined();
+    expect(body.Name).toBe("Beta wave");
+    expect(body.FeatureToggleUsages).toHaveLength(2);
+
+    expect(get).toHaveBeenCalledWith(
+      "~/api/{spaceId}/projects/{projectId}/featuretoggles/rollout-groups/{rolloutGroupId}",
+      {
+        spaceId: "Spaces-1",
+        projectId: "Projects-123",
+        rolloutGroupId: "RolloutGroups-3",
+      },
+    );
+  });
+
+  it("rejects an invalid rollout group ID before any API call", async () => {
+    await expect(
+      descriptorByName("rolloutGroup").read({
+        spaceName: "Default",
+        projectId: "Projects-123",
+        rolloutGroupId: "not-a-real-id",
+      }),
+    ).rejects.toThrow(/Invalid rollout group ID format/);
+
+    expect(get).not.toHaveBeenCalled();
+    expect(resolveSpaceId).not.toHaveBeenCalled();
+  });
+
+  it("translates 404 into a friendly error", async () => {
+    get.mockRejectedValueOnce(new Error("404 not found"));
+
+    await expect(
+      descriptorByName("rolloutGroup").read({
+        spaceName: "Default",
+        projectId: "Projects-123",
+        rolloutGroupId: "RolloutGroups-99",
+      }),
+    ).rejects.toThrow(/not found in space 'Default'/);
+  });
+});

--- a/src/resources/__tests__/rolloutGroup.test.ts
+++ b/src/resources/__tests__/rolloutGroup.test.ts
@@ -26,27 +26,11 @@ import {
 } from "../../types/resourceConfig.js";
 import "../rolloutGroup.js";
 
-function descriptorByName(name: string): ResourceDescriptor {
-  const descriptor = RESOURCE_REGISTRY.find((d) => d.name === name);
-  if (!descriptor) {
-    throw new Error(`Resource descriptor '${name}' is not registered.`);
-  }
-  return descriptor;
+function descriptor(name: string): ResourceDescriptor {
+  const d = RESOURCE_REGISTRY.find((r) => r.name === name);
+  if (!d) throw new Error(`Resource '${name}' not registered.`);
+  return d;
 }
-
-const sampleGroup = {
-  Id: "RolloutGroups-3",
-  SpaceId: "Spaces-1",
-  ProjectId: "Projects-123",
-  Name: "Beta wave",
-  FeatureToggleUsages: [
-    { Id: "FeatureToggles-9", Name: "checkout-redesign" },
-    { Id: "FeatureToggles-12", Name: "search-overhaul" },
-  ],
-  Links: {
-    Self: "/api/Spaces-1/projects/Projects-123/featuretoggles/rollout-groups/RolloutGroups-3",
-  },
-};
 
 describe("rolloutGroup resource", () => {
   beforeEach(() => {
@@ -55,21 +39,27 @@ describe("rolloutGroup resource", () => {
     resolveSpaceId.mockResolvedValue("Spaces-1");
   });
 
-  it("returns the full group body with Links stripped", async () => {
-    get.mockResolvedValueOnce(sampleGroup);
+  it("fetches the group at the project-scoped rollout-groups path and strips Links", async () => {
+    get.mockResolvedValueOnce({
+      Id: "RolloutGroups-3",
+      Name: "Beta wave",
+      FeatureToggleUsages: [
+        { Id: "FeatureToggles-9", Name: "checkout-redesign" },
+      ],
+      Links: {
+        Self: "/api/Spaces-1/projects/Projects-123/featuretoggles/rollout-groups/RolloutGroups-3",
+      },
+    });
 
-    const payload = await descriptorByName("rolloutGroup").read({
+    const payload = await descriptor("rolloutGroup").read({
       spaceName: "Default",
       projectId: "Projects-123",
       rolloutGroupId: "RolloutGroups-3",
     });
 
-    expect(payload.mimeType).toBe("application/json");
     const body = JSON.parse(payload.text);
-
     expect(body.Links).toBeUndefined();
-    expect(body.Name).toBe("Beta wave");
-    expect(body.FeatureToggleUsages).toHaveLength(2);
+    expect(body.FeatureToggleUsages).toHaveLength(1);
 
     expect(get).toHaveBeenCalledWith(
       "~/api/{spaceId}/projects/{projectId}/featuretoggles/rollout-groups/{rolloutGroupId}",
@@ -79,30 +69,5 @@ describe("rolloutGroup resource", () => {
         rolloutGroupId: "RolloutGroups-3",
       },
     );
-  });
-
-  it("rejects an invalid rollout group ID before any API call", async () => {
-    await expect(
-      descriptorByName("rolloutGroup").read({
-        spaceName: "Default",
-        projectId: "Projects-123",
-        rolloutGroupId: "not-a-real-id",
-      }),
-    ).rejects.toThrow(/Invalid rollout group ID format/);
-
-    expect(get).not.toHaveBeenCalled();
-    expect(resolveSpaceId).not.toHaveBeenCalled();
-  });
-
-  it("translates 404 into a friendly error", async () => {
-    get.mockRejectedValueOnce(new Error("404 not found"));
-
-    await expect(
-      descriptorByName("rolloutGroup").read({
-        spaceName: "Default",
-        projectId: "Projects-123",
-        rolloutGroupId: "RolloutGroups-99",
-      }),
-    ).rejects.toThrow(/not found in space 'Default'/);
   });
 });

--- a/src/resources/dispatch.ts
+++ b/src/resources/dispatch.ts
@@ -5,6 +5,13 @@
  * `read_resource` Tool backstop (src/tools/readResource.ts) flow through the
  * same descriptor registry, so resource-aware clients (which call resources/read)
  * and resource-less clients (which call the Tool wrapper) hit identical logic.
+ *
+ * Toolset filtering is enforced at dispatch time. Native MCP clients only
+ * see resources whose toolset is enabled because registerResources skips
+ * disabled descriptors at registration. The `read_resource` backstop, by
+ * contrast, is registered under `core` and is always available — so without
+ * filtering here a caller could guess a URI for a descriptor whose toolset
+ * is disabled and still fetch the body. The filter below closes that gap.
  */
 
 import { UriTemplate } from "@modelcontextprotocol/sdk/shared/uriTemplate.js";
@@ -13,6 +20,12 @@ import {
   type ResourceDescriptor,
   type ResourcePayload,
 } from "../types/resourceConfig.js";
+import {
+  DEFAULT_TOOLSETS,
+  type Toolset,
+  type ToolsetConfig,
+} from "../types/toolConfig.js";
+import { getActiveToolsetConfig } from "../helpers/activeToolsetConfig.js";
 
 const COMPILED = new WeakMap<ResourceDescriptor, UriTemplate>();
 
@@ -55,16 +68,29 @@ function safeDecode(value: string): string {
   }
 }
 
+function isToolsetEnabled(toolset: Toolset, config: ToolsetConfig): boolean {
+  if (toolset === "core") return true;
+  const enabled =
+    config.enabledToolsets === "all"
+      ? DEFAULT_TOOLSETS
+      : config.enabledToolsets || DEFAULT_TOOLSETS;
+  return enabled.includes(toolset);
+}
+
 export async function dispatchOctopusUri(
   uri: string,
 ): Promise<ResourcePayload | null> {
   if (!uri.startsWith("octopus://")) return null;
 
+  const config = getActiveToolsetConfig();
   for (const descriptor of RESOURCE_REGISTRY) {
     const variables = compiled(descriptor).match(uri);
-    if (variables) {
-      return descriptor.read(flatten(variables));
-    }
+    if (!variables) continue;
+    // Even though the URI matches, the descriptor's toolset may be disabled
+    // for this session. Skip and keep looking — but no other descriptor
+    // should claim the same template, so this effectively returns null.
+    if (!isToolsetEnabled(descriptor.toolset, config)) continue;
+    return descriptor.read(flatten(variables));
   }
 
   return null;

--- a/src/resources/featureToggle.ts
+++ b/src/resources/featureToggle.ts
@@ -1,0 +1,42 @@
+import { Client, resolveSpaceId } from "@octopusdeploy/api-client";
+import { registerResourceDescriptor } from "../types/resourceConfig.js";
+import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
+import { handleOctopusApiError } from "../helpers/errorHandling.js";
+import { stripLinks } from "../helpers/stripLinks.js";
+import { type FeatureToggleResource } from "../types/featureToggleTypes.js";
+
+registerResourceDescriptor({
+  name: "featureToggle",
+  uriTemplate:
+    "octopus://spaces/{spaceName}/projects/{projectId}/featuretoggles/{slug}",
+  toolset: "featureToggles",
+  title: "Octopus feature toggle",
+  description:
+    "Full customer feature toggle body for a given slug in a project. Includes per-environment configuration (tenants, segments, minimum versions) that the find_feature_toggles slim summary omits.",
+  mimeType: "application/json",
+  read: async ({ spaceName, projectId, slug }) => {
+    try {
+      const client = await Client.create(
+        getClientConfigurationFromEnvironment(),
+      );
+      const spaceId = await resolveSpaceId(client, spaceName);
+      const toggle = await client.get<FeatureToggleResource>(
+        "~/api/{spaceId}/projects/{projectId}/featuretoggles/{slug}",
+        { spaceId, projectId, slug },
+      );
+
+      return {
+        mimeType: "application/json",
+        text: JSON.stringify(stripLinks(toggle)),
+      };
+    } catch (error) {
+      handleOctopusApiError(error, {
+        entityType: "feature toggle",
+        entityId: slug,
+        spaceName,
+        helpText:
+          "Use find_feature_toggles to list valid slugs. If 404 persists across all toggles, the customer feature toggles capability may be disabled on the Octopus instance.",
+      });
+    }
+  },
+});

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -12,6 +12,8 @@ import "./release.js";
 import "./runbook.js";
 import "./task.js";
 import "./interruption.js";
+import "./featureToggle.js";
+import "./rolloutGroup.js";
 
 function isToolsetEnabled(toolset: Toolset, config: ToolsetConfig): boolean {
   const enabled: Toolset[] =

--- a/src/resources/rolloutGroup.ts
+++ b/src/resources/rolloutGroup.ts
@@ -1,0 +1,47 @@
+import { Client, resolveSpaceId } from "@octopusdeploy/api-client";
+import { registerResourceDescriptor } from "../types/resourceConfig.js";
+import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
+import {
+  validateEntityId,
+  handleOctopusApiError,
+} from "../helpers/errorHandling.js";
+import { stripLinks } from "../helpers/stripLinks.js";
+import { type RolloutGroupResource } from "../types/featureToggleTypes.js";
+
+registerResourceDescriptor({
+  name: "rolloutGroup",
+  uriTemplate:
+    "octopus://spaces/{spaceName}/projects/{projectId}/rolloutgroups/{rolloutGroupId}",
+  toolset: "featureToggles",
+  title: "Octopus feature toggle rollout group",
+  description:
+    "Full rollout group body for a given rollout group ID in a project. Lists the feature toggles bound to the group via FeatureToggleUsages. Read-only — this MCP server does not expose rollout group create/modify/delete; use the Octopus UI for those.",
+  mimeType: "application/json",
+  read: async ({ spaceName, projectId, rolloutGroupId }) => {
+    validateEntityId(rolloutGroupId, "rollout group", "RolloutGroups-");
+
+    try {
+      const client = await Client.create(
+        getClientConfigurationFromEnvironment(),
+      );
+      const spaceId = await resolveSpaceId(client, spaceName);
+      const group = await client.get<RolloutGroupResource>(
+        "~/api/{spaceId}/projects/{projectId}/featuretoggles/rollout-groups/{rolloutGroupId}",
+        { spaceId, projectId, rolloutGroupId },
+      );
+
+      return {
+        mimeType: "application/json",
+        text: JSON.stringify(stripLinks(group)),
+      };
+    } catch (error) {
+      handleOctopusApiError(error, {
+        entityType: "rollout group",
+        entityId: rolloutGroupId,
+        spaceName,
+        helpText:
+          "Rollout group IDs surface as RolloutGroupId on toggles returned from find_feature_toggles. They are unique per project.",
+      });
+    }
+  },
+});

--- a/src/tools/__tests__/findFeatureToggles.handler.test.ts
+++ b/src/tools/__tests__/findFeatureToggles.handler.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const get = vi.fn();
+const resolveSpaceId = vi.fn();
+
+vi.mock("../../helpers/getClientConfigurationFromEnvironment.js", () => ({
+  getClientConfigurationFromEnvironment: () => ({
+    instanceURL: "https://octopus.example",
+    apiKey: "API-TEST",
+  }),
+}));
+
+vi.mock("@octopusdeploy/api-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@octopusdeploy/api-client")>();
+  return {
+    ...actual,
+    Client: { create: vi.fn(async () => ({ get })) },
+    resolveSpaceId: (...args: unknown[]) => resolveSpaceId(...args),
+  };
+});
+
+import { findFeatureTogglesHandler } from "../findFeatureToggles.js";
+import { parseToolResponse } from "./testSetup.js";
+
+interface ToggleSummary {
+  id: string;
+  slug: string;
+  name: string;
+  projectId: string;
+  defaultIsEnabled: boolean;
+  rolloutGroupId: string | null;
+  tags: string[];
+  environmentSummaries: Array<{
+    deploymentEnvironmentId: string;
+    isEnabled: boolean;
+    rolloutPercentage?: number;
+    clientRolloutPercentage?: number;
+  }>;
+  resourceUri: string;
+}
+
+interface ListResponse {
+  totalResults: number;
+  itemsPerPage: number;
+  numberOfPages: number;
+  lastPageNumber: number;
+  items: ToggleSummary[];
+}
+
+function makeToggle(overrides: {
+  id: number;
+  slug?: string;
+  name?: string;
+  defaultIsEnabled?: boolean;
+  rolloutGroupId?: string | null;
+  environments?: Array<{
+    deploymentEnvironmentId: string;
+    isEnabled: boolean;
+    rolloutPercentage?: number;
+    clientRolloutPercentage?: number;
+  }>;
+}) {
+  return {
+    Id: `FeatureToggles-${overrides.id}`,
+    SpaceId: "Spaces-1",
+    ProjectId: "Projects-123",
+    Name: overrides.name ?? `toggle-${overrides.id}`,
+    Slug: overrides.slug ?? `toggle-${overrides.id}`,
+    DefaultIsEnabled: overrides.defaultIsEnabled ?? false,
+    Description: null,
+    Environments: (overrides.environments ?? []).map((e) => ({
+      DeploymentEnvironmentId: e.deploymentEnvironmentId,
+      IsEnabled: e.isEnabled,
+      RolloutPercentage: e.rolloutPercentage,
+      ClientRolloutPercentage: e.clientRolloutPercentage,
+      TenantIds: [],
+      ExcludedTenantIds: [],
+      TenantTags: [],
+      ExcludedTenantTags: [],
+      Segments: [],
+      MinimumVersion: null,
+    })),
+    Tags: [],
+    RolloutGroupId: overrides.rolloutGroupId ?? null,
+  };
+}
+
+describe("findFeatureTogglesHandler", () => {
+  beforeEach(() => {
+    get.mockReset();
+    resolveSpaceId.mockReset();
+    resolveSpaceId.mockResolvedValue("Spaces-1");
+  });
+
+  it("returns slim summaries with per-environment state and a resource URI", async () => {
+    get.mockResolvedValueOnce({
+      TotalResults: 1,
+      ItemsPerPage: 30,
+      NumberOfPages: 1,
+      LastPageNumber: 0,
+      Items: [
+        makeToggle({
+          id: 9,
+          slug: "checkout-redesign",
+          name: "checkout-redesign",
+          defaultIsEnabled: false,
+          environments: [
+            {
+              deploymentEnvironmentId: "Environments-7",
+              isEnabled: true,
+              rolloutPercentage: 25,
+              clientRolloutPercentage: 50,
+            },
+          ],
+        }),
+      ],
+    });
+
+    const response = await findFeatureTogglesHandler({
+      spaceName: "Default",
+      projectId: "Projects-123",
+    });
+    const body = parseToolResponse<ListResponse>(response);
+
+    expect(body.totalResults).toBe(1);
+    expect(body.items).toHaveLength(1);
+    const item = body.items[0];
+    expect(item.id).toBe("FeatureToggles-9");
+    expect(item.slug).toBe("checkout-redesign");
+    expect(item.defaultIsEnabled).toBe(false);
+    expect(item.environmentSummaries).toEqual([
+      {
+        deploymentEnvironmentId: "Environments-7",
+        isEnabled: true,
+        rolloutPercentage: 25,
+        clientRolloutPercentage: 50,
+      },
+    ]);
+    expect(item.resourceUri).toBe(
+      "octopus://spaces/Default/projects/Projects-123/featuretoggles/checkout-redesign",
+    );
+  });
+
+  it("URL-encodes spaceName, projectId, and slug in the resource URI", async () => {
+    get.mockResolvedValueOnce({
+      TotalResults: 1,
+      ItemsPerPage: 30,
+      NumberOfPages: 1,
+      LastPageNumber: 0,
+      Items: [
+        makeToggle({
+          id: 1,
+          slug: "feature/with slashes",
+          name: "messy",
+        }),
+      ],
+    });
+
+    const response = await findFeatureTogglesHandler({
+      spaceName: "AI Foundations",
+      projectId: "Projects-123",
+    });
+    const body = parseToolResponse<ListResponse>(response);
+
+    expect(body.items[0].resourceUri).toBe(
+      "octopus://spaces/AI%20Foundations/projects/Projects-123/featuretoggles/feature%2Fwith%20slashes",
+    );
+  });
+
+  it("passes filter args through to the URI template", async () => {
+    get.mockResolvedValueOnce({
+      TotalResults: 0,
+      ItemsPerPage: 30,
+      NumberOfPages: 1,
+      LastPageNumber: 0,
+      Items: [],
+    });
+
+    await findFeatureTogglesHandler({
+      spaceName: "Default",
+      projectId: "Projects-123",
+      partialName: "checkout",
+      tags: ["release-rings/beta", "team/payments"],
+      environmentIds: ["Environments-7", "Environments-8"],
+      skip: 30,
+      take: 30,
+    });
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith(
+      "~/api/{spaceId}/projects/{projectId}/featuretoggles{?Skip,Take,PartialName,Tags,Environments}",
+      {
+        spaceId: "Spaces-1",
+        projectId: "Projects-123",
+        Skip: 30,
+        Take: 30,
+        PartialName: "checkout",
+        Tags: ["release-rings/beta", "team/payments"],
+        Environments: ["Environments-7", "Environments-8"],
+      },
+    );
+  });
+
+  it("translates a 404 from the listing endpoint into the disabled-capability hint", async () => {
+    get.mockRejectedValueOnce(new Error("Not found (404)"));
+
+    await expect(
+      findFeatureTogglesHandler({
+        spaceName: "Default",
+        projectId: "Projects-123",
+      }),
+    ).rejects.toThrow(/customer feature toggles capability is disabled/);
+  });
+
+  it("propagates pagination metadata from the server response", async () => {
+    get.mockResolvedValueOnce({
+      TotalResults: 47,
+      ItemsPerPage: 30,
+      NumberOfPages: 2,
+      LastPageNumber: 1,
+      Items: [makeToggle({ id: 1 }), makeToggle({ id: 2 })],
+    });
+
+    const response = await findFeatureTogglesHandler({
+      spaceName: "Default",
+      projectId: "Projects-123",
+    });
+    const body = parseToolResponse<ListResponse>(response);
+
+    expect(body.totalResults).toBe(47);
+    expect(body.itemsPerPage).toBe(30);
+    expect(body.numberOfPages).toBe(2);
+    expect(body.lastPageNumber).toBe(1);
+    expect(body.items).toHaveLength(2);
+  });
+});

--- a/src/tools/__tests__/findFeatureToggles.handler.test.ts
+++ b/src/tools/__tests__/findFeatureToggles.handler.test.ts
@@ -23,68 +23,45 @@ vi.mock("@octopusdeploy/api-client", async (importOriginal) => {
 import { findFeatureTogglesHandler } from "../findFeatureToggles.js";
 import { parseToolResponse } from "./testSetup.js";
 
-interface ToggleSummary {
-  id: string;
-  slug: string;
-  name: string;
-  projectId: string;
-  defaultIsEnabled: boolean;
-  rolloutGroupId: string | null;
-  tags: string[];
-  environmentSummaries: Array<{
-    deploymentEnvironmentId: string;
-    isEnabled: boolean;
-    rolloutPercentage?: number;
-    clientRolloutPercentage?: number;
-  }>;
-  resourceUri: string;
-}
-
 interface ListResponse {
   totalResults: number;
-  itemsPerPage: number;
-  numberOfPages: number;
-  lastPageNumber: number;
-  items: ToggleSummary[];
+  items: Array<{
+    id: string;
+    slug: string;
+    name: string;
+    defaultIsEnabled: boolean;
+    rolloutGroupId: string | null;
+    environmentSummaries: Array<{
+      deploymentEnvironmentId: string;
+      isEnabled: boolean;
+      rolloutPercentage?: number;
+      clientRolloutPercentage?: number;
+    }>;
+    resourceUri: string;
+  }>;
 }
 
-function makeToggle(overrides: {
-  id: number;
-  slug?: string;
-  name?: string;
-  defaultIsEnabled?: boolean;
-  rolloutGroupId?: string | null;
-  environments?: Array<{
-    deploymentEnvironmentId: string;
-    isEnabled: boolean;
-    rolloutPercentage?: number;
-    clientRolloutPercentage?: number;
-  }>;
-}) {
-  return {
-    Id: `FeatureToggles-${overrides.id}`,
-    SpaceId: "Spaces-1",
-    ProjectId: "Projects-123",
-    Name: overrides.name ?? `toggle-${overrides.id}`,
-    Slug: overrides.slug ?? `toggle-${overrides.id}`,
-    DefaultIsEnabled: overrides.defaultIsEnabled ?? false,
-    Description: null,
-    Environments: (overrides.environments ?? []).map((e) => ({
-      DeploymentEnvironmentId: e.deploymentEnvironmentId,
-      IsEnabled: e.isEnabled,
-      RolloutPercentage: e.rolloutPercentage,
-      ClientRolloutPercentage: e.clientRolloutPercentage,
-      TenantIds: [],
-      ExcludedTenantIds: [],
-      TenantTags: [],
-      ExcludedTenantTags: [],
-      Segments: [],
-      MinimumVersion: null,
-    })),
-    Tags: [],
-    RolloutGroupId: overrides.rolloutGroupId ?? null,
-  };
-}
+const sampleToggle = {
+  Id: "FeatureToggles-9",
+  SpaceId: "Spaces-1",
+  ProjectId: "Projects-123",
+  Name: "checkout-redesign",
+  Slug: "checkout-redesign",
+  DefaultIsEnabled: false,
+  Description: "ignored in slim summary",
+  Environments: [
+    {
+      DeploymentEnvironmentId: "Environments-7",
+      IsEnabled: true,
+      RolloutPercentage: 25,
+      ClientRolloutPercentage: 50,
+      TenantIds: ["Tenants-42"],
+      Segments: [{ Key: "browser", Value: "Chrome" }],
+    },
+  ],
+  Tags: ["release-rings/beta"],
+  RolloutGroupId: null,
+};
 
 describe("findFeatureTogglesHandler", () => {
   beforeEach(() => {
@@ -93,68 +70,13 @@ describe("findFeatureTogglesHandler", () => {
     resolveSpaceId.mockResolvedValue("Spaces-1");
   });
 
-  it("returns slim summaries with per-environment state and a resource URI", async () => {
+  it("maps the wire-format toggle to a slim summary with per-env state and a URL-encoded resourceUri", async () => {
     get.mockResolvedValueOnce({
       TotalResults: 1,
       ItemsPerPage: 30,
       NumberOfPages: 1,
       LastPageNumber: 0,
-      Items: [
-        makeToggle({
-          id: 9,
-          slug: "checkout-redesign",
-          name: "checkout-redesign",
-          defaultIsEnabled: false,
-          environments: [
-            {
-              deploymentEnvironmentId: "Environments-7",
-              isEnabled: true,
-              rolloutPercentage: 25,
-              clientRolloutPercentage: 50,
-            },
-          ],
-        }),
-      ],
-    });
-
-    const response = await findFeatureTogglesHandler({
-      spaceName: "Default",
-      projectId: "Projects-123",
-    });
-    const body = parseToolResponse<ListResponse>(response);
-
-    expect(body.totalResults).toBe(1);
-    expect(body.items).toHaveLength(1);
-    const item = body.items[0];
-    expect(item.id).toBe("FeatureToggles-9");
-    expect(item.slug).toBe("checkout-redesign");
-    expect(item.defaultIsEnabled).toBe(false);
-    expect(item.environmentSummaries).toEqual([
-      {
-        deploymentEnvironmentId: "Environments-7",
-        isEnabled: true,
-        rolloutPercentage: 25,
-        clientRolloutPercentage: 50,
-      },
-    ]);
-    expect(item.resourceUri).toBe(
-      "octopus://spaces/Default/projects/Projects-123/featuretoggles/checkout-redesign",
-    );
-  });
-
-  it("URL-encodes spaceName, projectId, and slug in the resource URI", async () => {
-    get.mockResolvedValueOnce({
-      TotalResults: 1,
-      ItemsPerPage: 30,
-      NumberOfPages: 1,
-      LastPageNumber: 0,
-      Items: [
-        makeToggle({
-          id: 1,
-          slug: "feature/with slashes",
-          name: "messy",
-        }),
-      ],
+      Items: [sampleToggle],
     });
 
     const response = await findFeatureTogglesHandler({
@@ -163,12 +85,23 @@ describe("findFeatureTogglesHandler", () => {
     });
     const body = parseToolResponse<ListResponse>(response);
 
+    expect(body.totalResults).toBe(1);
+    expect(body.items[0].environmentSummaries).toEqual([
+      {
+        deploymentEnvironmentId: "Environments-7",
+        isEnabled: true,
+        rolloutPercentage: 25,
+        clientRolloutPercentage: 50,
+      },
+    ]);
+    // Heavy fields (TenantIds, Segments, Description) intentionally absent
+    // from the slim summary — they live in the resource body.
     expect(body.items[0].resourceUri).toBe(
-      "octopus://spaces/AI%20Foundations/projects/Projects-123/featuretoggles/feature%2Fwith%20slashes",
+      "octopus://spaces/AI%20Foundations/projects/Projects-123/featuretoggles/checkout-redesign",
     );
   });
 
-  it("passes filter args through to the URI template", async () => {
+  it("forwards filter args to the URI template under the exact PascalCase names the server expects", async () => {
     get.mockResolvedValueOnce({
       TotalResults: 0,
       ItemsPerPage: 30,
@@ -181,13 +114,12 @@ describe("findFeatureTogglesHandler", () => {
       spaceName: "Default",
       projectId: "Projects-123",
       partialName: "checkout",
-      tags: ["release-rings/beta", "team/payments"],
-      environmentIds: ["Environments-7", "Environments-8"],
+      tags: ["release-rings/beta"],
+      environmentIds: ["Environments-7"],
       skip: 30,
       take: 30,
     });
 
-    expect(get).toHaveBeenCalledTimes(1);
     expect(get).toHaveBeenCalledWith(
       "~/api/{spaceId}/projects/{projectId}/featuretoggles{?Skip,Take,PartialName,Tags,Environments}",
       {
@@ -196,13 +128,17 @@ describe("findFeatureTogglesHandler", () => {
         Skip: 30,
         Take: 30,
         PartialName: "checkout",
-        Tags: ["release-rings/beta", "team/payments"],
-        Environments: ["Environments-7", "Environments-8"],
+        Tags: ["release-rings/beta"],
+        Environments: ["Environments-7"],
       },
     );
   });
 
-  it("translates a 404 from the listing endpoint into the disabled-capability hint", async () => {
+  it("translates a 404 from the listing endpoint into the disabled-capability hint, not a generic space-not-found", async () => {
+    // The space resolved fine; the 404 here means either the projectId is
+    // wrong or the customer feature toggles capability is off on this
+    // instance. The default handleOctopusApiError path would say "Space not
+    // found" — wrong message.
     get.mockRejectedValueOnce(new Error("Not found (404)"));
 
     await expect(
@@ -211,27 +147,5 @@ describe("findFeatureTogglesHandler", () => {
         projectId: "Projects-123",
       }),
     ).rejects.toThrow(/customer feature toggles capability is disabled/);
-  });
-
-  it("propagates pagination metadata from the server response", async () => {
-    get.mockResolvedValueOnce({
-      TotalResults: 47,
-      ItemsPerPage: 30,
-      NumberOfPages: 2,
-      LastPageNumber: 1,
-      Items: [makeToggle({ id: 1 }), makeToggle({ id: 2 })],
-    });
-
-    const response = await findFeatureTogglesHandler({
-      spaceName: "Default",
-      projectId: "Projects-123",
-    });
-    const body = parseToolResponse<ListResponse>(response);
-
-    expect(body.totalResults).toBe(47);
-    expect(body.itemsPerPage).toBe(30);
-    expect(body.numberOfPages).toBe(2);
-    expect(body.lastPageNumber).toBe(1);
-    expect(body.items).toHaveLength(2);
   });
 });

--- a/src/tools/__tests__/updateFeatureToggle.handler.test.ts
+++ b/src/tools/__tests__/updateFeatureToggle.handler.test.ts
@@ -23,74 +23,51 @@ vi.mock("@octopusdeploy/api-client", async (importOriginal) => {
 
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { updateFeatureToggleHandler } from "../updateFeatureToggle.js";
-import { parseToolResponse, assertToolResponse } from "./testSetup.js";
+import { assertToolResponse } from "./testSetup.js";
 import { type FeatureToggleResource } from "../../types/featureToggleTypes.js";
 
-interface ServerStub {
-  server: McpServer;
-  elicitInput: ReturnType<typeof vi.fn>;
-  getClientCapabilities: ReturnType<typeof vi.fn>;
-}
-
-function makeServerStub(opts: {
-  elicitation?: boolean;
+function makeServer(opts: {
   elicitResult?: { action: "accept" | "decline" | "cancel" };
-}): ServerStub {
-  const elicitInput = vi.fn(async () => opts.elicitResult ?? { action: "accept" });
-  const getClientCapabilities = vi.fn(() =>
-    opts.elicitation ? { elicitation: {} } : {},
-  );
-  const server = {
+} = {}): McpServer {
+  return {
     server: {
-      elicitInput,
-      getClientCapabilities,
+      elicitInput: vi.fn(async () => opts.elicitResult ?? { action: "accept" }),
+      getClientCapabilities: vi.fn(() => ({ elicitation: {} })),
     },
   } as unknown as McpServer;
-  return { server, elicitInput, getClientCapabilities };
 }
 
-function makeToggle(
-  overrides: Partial<FeatureToggleResource> = {},
-): FeatureToggleResource {
-  return {
-    Id: "FeatureToggles-9",
-    SpaceId: "Spaces-1",
-    ProjectId: "Projects-123",
-    Name: "checkout-redesign",
-    Slug: "checkout-redesign",
-    DefaultIsEnabled: false,
-    Description: "Old description",
-    Tags: ["release-rings/beta"],
-    RolloutGroupId: null,
-    Environments: [
-      {
-        DeploymentEnvironmentId: "Environments-7",
-        IsEnabled: true,
-        RolloutPercentage: 25,
-        ClientRolloutPercentage: 50,
-        TenantIds: ["Tenants-42"],
-        ExcludedTenantIds: [],
-        TenantTags: [],
-        ExcludedTenantTags: [],
-        Segments: [{ Key: "browser", Value: "Chrome" }],
-        MinimumVersion: "1.4.0",
-      },
-      {
-        DeploymentEnvironmentId: "Environments-8",
-        IsEnabled: false,
-        RolloutPercentage: 100,
-        ClientRolloutPercentage: 100,
-        TenantIds: [],
-        ExcludedTenantIds: [],
-        TenantTags: [],
-        ExcludedTenantTags: [],
-        Segments: [],
-        MinimumVersion: null,
-      },
-    ],
-    ...overrides,
-  };
-}
+const baseToggle: FeatureToggleResource = {
+  Id: "FeatureToggles-9",
+  SpaceId: "Spaces-1",
+  ProjectId: "Projects-123",
+  Name: "checkout-redesign",
+  Slug: "checkout-redesign",
+  DefaultIsEnabled: false,
+  Description: "Old description",
+  Tags: ["release-rings/beta"],
+  RolloutGroupId: null,
+  Environments: [
+    {
+      DeploymentEnvironmentId: "Environments-7",
+      IsEnabled: true,
+      RolloutPercentage: 25,
+      ClientRolloutPercentage: 50,
+      TenantIds: ["Tenants-42"],
+      Segments: [{ Key: "browser", Value: "Chrome" }],
+      MinimumVersion: "1.4.0",
+    },
+    {
+      DeploymentEnvironmentId: "Environments-8",
+      IsEnabled: false,
+      RolloutPercentage: 100,
+      ClientRolloutPercentage: 100,
+      TenantIds: [],
+      Segments: [],
+      MinimumVersion: null,
+    },
+  ],
+};
 
 describe("updateFeatureToggleHandler", () => {
   beforeEach(() => {
@@ -100,28 +77,62 @@ describe("updateFeatureToggleHandler", () => {
     resolveSpaceId.mockResolvedValue("Spaces-1");
   });
 
-  it("rejects calls with no patches", async () => {
-    const { server } = makeServerStub({ elicitation: true });
+  it("merges patches into the current toggle: targeted env field changes, unmentioned env fields preserved, unmentioned envs untouched, toggle-level fields applied", async () => {
+    get.mockResolvedValueOnce(baseToggle);
+    doUpdate.mockResolvedValueOnce(undefined);
 
-    const response = await updateFeatureToggleHandler(server, {
+    await updateFeatureToggleHandler(makeServer(), {
       spaceName: "Default",
       projectId: "Projects-123",
       slug: "checkout-redesign",
+      defaultIsEnabled: true,
+      environments: [
+        {
+          deploymentEnvironmentId: "Environments-7",
+          rolloutPercentage: 75,
+        },
+      ],
     });
 
-    assertToolResponse(response);
-    expect(response.isError).toBe(true);
-    const body = JSON.parse(response.content[0].text);
-    expect(body.reason).toBe("no_patches");
-    expect(get).not.toHaveBeenCalled();
-    expect(doUpdate).not.toHaveBeenCalled();
+    expect(doUpdate).toHaveBeenCalledTimes(1);
+    const [, body] = doUpdate.mock.calls[0];
+
+    // Toggle-level patch applied
+    expect(body.DefaultIsEnabled).toBe(true);
+    // Toggle-level fields not in the patch are preserved
+    expect(body.Description).toBe("Old description");
+    expect(body.Name).toBe("checkout-redesign");
+    expect(body.Slug).toBe("checkout-redesign");
+    expect(body.Tags).toEqual(["release-rings/beta"]);
+
+    // Env-7: patched field updated, all other fields preserved (the
+    // failure mode this guards against is the PUT replacing the whole
+    // env body and dropping TenantIds, Segments, MinimumVersion, etc.)
+    const env7 = body.Environments.find(
+      (e: { DeploymentEnvironmentId: string }) =>
+        e.DeploymentEnvironmentId === "Environments-7",
+    );
+    expect(env7).toMatchObject({
+      RolloutPercentage: 75,
+      IsEnabled: true,
+      ClientRolloutPercentage: 50,
+      TenantIds: ["Tenants-42"],
+      Segments: [{ Key: "browser", Value: "Chrome" }],
+      MinimumVersion: "1.4.0",
+    });
+
+    // Env-8: not mentioned in the patch, preserved verbatim
+    const env8 = body.Environments.find(
+      (e: { DeploymentEnvironmentId: string }) =>
+        e.DeploymentEnvironmentId === "Environments-8",
+    );
+    expect(env8).toEqual(baseToggle.Environments[1]);
   });
 
-  it("rejects a patch targeting an environment that isn't on the toggle", async () => {
-    const { server } = makeServerStub({ elicitation: true });
-    get.mockResolvedValueOnce(makeToggle());
+  it("rejects a patch targeting an environment that isn't on the toggle, instead of silently adding it", async () => {
+    get.mockResolvedValueOnce(baseToggle);
 
-    const response = await updateFeatureToggleHandler(server, {
+    const response = await updateFeatureToggleHandler(makeServer(), {
       spaceName: "Default",
       projectId: "Projects-123",
       slug: "checkout-redesign",
@@ -134,191 +145,30 @@ describe("updateFeatureToggleHandler", () => {
     expect(response.isError).toBe(true);
     const body = JSON.parse(response.content[0].text);
     expect(body.reason).toBe("environment_not_configured");
-    expect(body.configuredEnvironmentIds).toEqual([
-      "Environments-7",
-      "Environments-8",
-    ]);
     expect(doUpdate).not.toHaveBeenCalled();
   });
 
-  it("returns noOp when every supplied field already matches current state", async () => {
-    const { server } = makeServerStub({ elicitation: true });
-    const current = makeToggle();
-    get.mockResolvedValueOnce(current);
+  it("does not issue the PUT when the user declines the elicitation prompt", async () => {
+    // The full matrix of confirmation outcomes (envSkip / accepted /
+    // fallbackConfirm / cancelled / confirmationRequired) is exercised in
+    // requireConfirmation.test.ts. Here we only verify the integration —
+    // a "no" answer from the user must not result in a server-side write.
+    get.mockResolvedValueOnce(baseToggle);
 
-    const response = await updateFeatureToggleHandler(server, {
-      spaceName: "Default",
-      projectId: "Projects-123",
-      slug: "checkout-redesign",
-      defaultIsEnabled: current.DefaultIsEnabled,
-      environments: [
-        {
-          deploymentEnvironmentId: "Environments-7",
-          rolloutPercentage: current.Environments[0].RolloutPercentage,
-        },
-      ],
-    });
-
-    const body = parseToolResponse<{ success: boolean; noOp: boolean }>(response);
-    expect(body.success).toBe(true);
-    expect(body.noOp).toBe(true);
-    expect(doUpdate).not.toHaveBeenCalled();
-  });
-
-  it("merges per-environment patches and preserves unmentioned envs and fields", async () => {
-    const { server } = makeServerStub({ elicitation: true });
-    const current = makeToggle();
-    get.mockResolvedValueOnce(current);
-    doUpdate.mockResolvedValueOnce(undefined);
-
-    const response = await updateFeatureToggleHandler(server, {
-      spaceName: "Default",
-      projectId: "Projects-123",
-      slug: "checkout-redesign",
-      environments: [
-        {
-          deploymentEnvironmentId: "Environments-7",
-          rolloutPercentage: 75,
-        },
-      ],
-    });
-
-    expect(doUpdate).toHaveBeenCalledTimes(1);
-    const [path, body, args] = doUpdate.mock.calls[0];
-    expect(path).toBe("~/api/{spaceId}/projects/{projectId}/featuretoggles");
-    expect(args).toEqual({ spaceId: "Spaces-1", projectId: "Projects-123" });
-
-    // Envs-7 patched
-    const env7 = body.Environments.find(
-      (e: { DeploymentEnvironmentId: string }) =>
-        e.DeploymentEnvironmentId === "Environments-7",
-    );
-    expect(env7.RolloutPercentage).toBe(75);
-    // Other fields on Envs-7 preserved
-    expect(env7.IsEnabled).toBe(true);
-    expect(env7.ClientRolloutPercentage).toBe(50);
-    expect(env7.TenantIds).toEqual(["Tenants-42"]);
-    expect(env7.Segments).toEqual([{ Key: "browser", Value: "Chrome" }]);
-    expect(env7.MinimumVersion).toBe("1.4.0");
-
-    // Envs-8 untouched
-    const env8 = body.Environments.find(
-      (e: { DeploymentEnvironmentId: string }) =>
-        e.DeploymentEnvironmentId === "Environments-8",
-    );
-    expect(env8.RolloutPercentage).toBe(100);
-    expect(env8.IsEnabled).toBe(false);
-
-    // Toggle-level fields preserved
-    expect(body.Name).toBe("checkout-redesign");
-    expect(body.Slug).toBe("checkout-redesign");
-    expect(body.Id).toBe("FeatureToggles-9");
-    expect(body.DefaultIsEnabled).toBe(false);
-    expect(body.Description).toBe("Old description");
-    expect(body.Tags).toEqual(["release-rings/beta"]);
-
-    // Success response
-    const respBody = parseToolResponse<{ success: boolean; resourceUri: string }>(
-      response,
-    );
-    expect(respBody.success).toBe(true);
-    expect(respBody.resourceUri).toBe(
-      "octopus://spaces/Default/projects/Projects-123/featuretoggles/checkout-redesign",
-    );
-  });
-
-  it("applies toggle-level patches (defaultIsEnabled, description) without touching environments", async () => {
-    const { server } = makeServerStub({ elicitation: true });
-    const current = makeToggle();
-    get.mockResolvedValueOnce(current);
-    doUpdate.mockResolvedValueOnce(undefined);
-
-    await updateFeatureToggleHandler(server, {
-      spaceName: "Default",
-      projectId: "Projects-123",
-      slug: "checkout-redesign",
-      defaultIsEnabled: true,
-      description: "Updated description",
-    });
-
-    const [, body] = doUpdate.mock.calls[0];
-    expect(body.DefaultIsEnabled).toBe(true);
-    expect(body.Description).toBe("Updated description");
-    // Environments untouched
-    expect(body.Environments).toEqual(current.Environments);
-  });
-
-  it("aborts when the user declines elicitation", async () => {
-    const { server, elicitInput } = makeServerStub({
-      elicitation: true,
-      elicitResult: { action: "decline" },
-    });
-    get.mockResolvedValueOnce(makeToggle());
-
-    const response = await updateFeatureToggleHandler(server, {
-      spaceName: "Default",
-      projectId: "Projects-123",
-      slug: "checkout-redesign",
-      defaultIsEnabled: true,
-    });
-
-    expect(elicitInput).toHaveBeenCalledTimes(1);
-    expect(doUpdate).not.toHaveBeenCalled();
-    const body = parseToolResponse<{ success: boolean; cancelled: boolean }>(
-      response,
-    );
-    expect(body.success).toBe(false);
-    expect(body.cancelled).toBe(true);
-  });
-
-  it("returns confirmationRequired when client lacks elicitation and confirm is omitted", async () => {
-    const { server } = makeServerStub({ elicitation: false });
-    get.mockResolvedValueOnce(makeToggle());
-
-    const response = await updateFeatureToggleHandler(server, {
-      spaceName: "Default",
-      projectId: "Projects-123",
-      slug: "checkout-redesign",
-      defaultIsEnabled: true,
-    });
-
-    assertToolResponse(response);
-    expect(response.isError).toBe(true);
-    const body = JSON.parse(response.content[0].text);
-    expect(body.confirmationRequired).toBe(true);
-    expect(doUpdate).not.toHaveBeenCalled();
-  });
-
-  it("proceeds without elicitation when confirm: true is supplied as fallback", async () => {
-    const { server, elicitInput } = makeServerStub({ elicitation: false });
-    get.mockResolvedValueOnce(makeToggle());
-    doUpdate.mockResolvedValueOnce(undefined);
-
-    const response = await updateFeatureToggleHandler(server, {
-      spaceName: "Default",
-      projectId: "Projects-123",
-      slug: "checkout-redesign",
-      defaultIsEnabled: true,
-      confirm: true,
-    });
-
-    expect(elicitInput).not.toHaveBeenCalled();
-    expect(doUpdate).toHaveBeenCalledTimes(1);
-    const body = parseToolResponse<{ success: boolean }>(response);
-    expect(body.success).toBe(true);
-  });
-
-  it("translates a 404 from the GET into the disabled-capability hint", async () => {
-    const { server } = makeServerStub({ elicitation: true });
-    get.mockRejectedValueOnce(new Error("Not found (404)"));
-
-    await expect(
-      updateFeatureToggleHandler(server, {
+    const response = await updateFeatureToggleHandler(
+      makeServer({ elicitResult: { action: "decline" } }),
+      {
         spaceName: "Default",
         projectId: "Projects-123",
-        slug: "missing",
+        slug: "checkout-redesign",
         defaultIsEnabled: true,
-      }),
-    ).rejects.toThrow(/not found in space 'Default'/);
+      },
+    );
+
+    expect(doUpdate).not.toHaveBeenCalled();
+    assertToolResponse(response);
+    const body = JSON.parse(response.content[0].text);
+    expect(body.success).toBe(false);
+    expect(body.cancelled).toBe(true);
   });
 });

--- a/src/tools/__tests__/updateFeatureToggle.handler.test.ts
+++ b/src/tools/__tests__/updateFeatureToggle.handler.test.ts
@@ -22,7 +22,10 @@ vi.mock("@octopusdeploy/api-client", async (importOriginal) => {
 });
 
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { updateFeatureToggleHandler } from "../updateFeatureToggle.js";
+import {
+  updateFeatureToggleHandler,
+  updateFeatureToggleSchema,
+} from "../updateFeatureToggle.js";
 import { assertToolResponse } from "./testSetup.js";
 import { type FeatureToggleResource } from "../../types/featureToggleTypes.js";
 
@@ -146,6 +149,27 @@ describe("updateFeatureToggleHandler", () => {
     const body = JSON.parse(response.content[0].text);
     expect(body.reason).toBe("environment_not_configured");
     expect(doUpdate).not.toHaveBeenCalled();
+  });
+
+  it("rejects duplicate deploymentEnvironmentId entries at the schema layer", () => {
+    // If the schema permitted duplicates, the merge would apply the first
+    // patch while the confirmation diff overwrote earlier entries with later
+    // ones — the user could approve one change and a different one would go
+    // through. Catch it before it reaches the handler.
+    const result = updateFeatureToggleSchema.safeParse({
+      spaceName: "Default",
+      projectId: "Projects-123",
+      slug: "checkout-redesign",
+      environments: [
+        { deploymentEnvironmentId: "Environments-7", isEnabled: true },
+        { deploymentEnvironmentId: "Environments-7", rolloutPercentage: 50 },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message).join("\n");
+      expect(messages).toMatch(/Duplicate environment entry/);
+    }
   });
 
   it("does not issue the PUT when the user declines the elicitation prompt", async () => {

--- a/src/tools/__tests__/updateFeatureToggle.handler.test.ts
+++ b/src/tools/__tests__/updateFeatureToggle.handler.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const get = vi.fn();
+const doUpdate = vi.fn();
+const resolveSpaceId = vi.fn();
+
+vi.mock("../../helpers/getClientConfigurationFromEnvironment.js", () => ({
+  getClientConfigurationFromEnvironment: () => ({
+    instanceURL: "https://octopus.example",
+    apiKey: "API-TEST",
+  }),
+}));
+
+vi.mock("@octopusdeploy/api-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@octopusdeploy/api-client")>();
+  return {
+    ...actual,
+    Client: { create: vi.fn(async () => ({ get, doUpdate })) },
+    resolveSpaceId: (...args: unknown[]) => resolveSpaceId(...args),
+  };
+});
+
+import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { updateFeatureToggleHandler } from "../updateFeatureToggle.js";
+import { parseToolResponse, assertToolResponse } from "./testSetup.js";
+import { type FeatureToggleResource } from "../../types/featureToggleTypes.js";
+
+interface ServerStub {
+  server: McpServer;
+  elicitInput: ReturnType<typeof vi.fn>;
+  getClientCapabilities: ReturnType<typeof vi.fn>;
+}
+
+function makeServerStub(opts: {
+  elicitation?: boolean;
+  elicitResult?: { action: "accept" | "decline" | "cancel" };
+}): ServerStub {
+  const elicitInput = vi.fn(async () => opts.elicitResult ?? { action: "accept" });
+  const getClientCapabilities = vi.fn(() =>
+    opts.elicitation ? { elicitation: {} } : {},
+  );
+  const server = {
+    server: {
+      elicitInput,
+      getClientCapabilities,
+    },
+  } as unknown as McpServer;
+  return { server, elicitInput, getClientCapabilities };
+}
+
+function makeToggle(
+  overrides: Partial<FeatureToggleResource> = {},
+): FeatureToggleResource {
+  return {
+    Id: "FeatureToggles-9",
+    SpaceId: "Spaces-1",
+    ProjectId: "Projects-123",
+    Name: "checkout-redesign",
+    Slug: "checkout-redesign",
+    DefaultIsEnabled: false,
+    Description: "Old description",
+    Tags: ["release-rings/beta"],
+    RolloutGroupId: null,
+    Environments: [
+      {
+        DeploymentEnvironmentId: "Environments-7",
+        IsEnabled: true,
+        RolloutPercentage: 25,
+        ClientRolloutPercentage: 50,
+        TenantIds: ["Tenants-42"],
+        ExcludedTenantIds: [],
+        TenantTags: [],
+        ExcludedTenantTags: [],
+        Segments: [{ Key: "browser", Value: "Chrome" }],
+        MinimumVersion: "1.4.0",
+      },
+      {
+        DeploymentEnvironmentId: "Environments-8",
+        IsEnabled: false,
+        RolloutPercentage: 100,
+        ClientRolloutPercentage: 100,
+        TenantIds: [],
+        ExcludedTenantIds: [],
+        TenantTags: [],
+        ExcludedTenantTags: [],
+        Segments: [],
+        MinimumVersion: null,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("updateFeatureToggleHandler", () => {
+  beforeEach(() => {
+    get.mockReset();
+    doUpdate.mockReset();
+    resolveSpaceId.mockReset();
+    resolveSpaceId.mockResolvedValue("Spaces-1");
+  });
+
+  it("rejects calls with no patches", async () => {
+    const { server } = makeServerStub({ elicitation: true });
+
+    const response = await updateFeatureToggleHandler(server, {
+      spaceName: "Default",
+      projectId: "Projects-123",
+      slug: "checkout-redesign",
+    });
+
+    assertToolResponse(response);
+    expect(response.isError).toBe(true);
+    const body = JSON.parse(response.content[0].text);
+    expect(body.reason).toBe("no_patches");
+    expect(get).not.toHaveBeenCalled();
+    expect(doUpdate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a patch targeting an environment that isn't on the toggle", async () => {
+    const { server } = makeServerStub({ elicitation: true });
+    get.mockResolvedValueOnce(makeToggle());
+
+    const response = await updateFeatureToggleHandler(server, {
+      spaceName: "Default",
+      projectId: "Projects-123",
+      slug: "checkout-redesign",
+      environments: [
+        { deploymentEnvironmentId: "Environments-99", isEnabled: true },
+      ],
+    });
+
+    assertToolResponse(response);
+    expect(response.isError).toBe(true);
+    const body = JSON.parse(response.content[0].text);
+    expect(body.reason).toBe("environment_not_configured");
+    expect(body.configuredEnvironmentIds).toEqual([
+      "Environments-7",
+      "Environments-8",
+    ]);
+    expect(doUpdate).not.toHaveBeenCalled();
+  });
+
+  it("returns noOp when every supplied field already matches current state", async () => {
+    const { server } = makeServerStub({ elicitation: true });
+    const current = makeToggle();
+    get.mockResolvedValueOnce(current);
+
+    const response = await updateFeatureToggleHandler(server, {
+      spaceName: "Default",
+      projectId: "Projects-123",
+      slug: "checkout-redesign",
+      defaultIsEnabled: current.DefaultIsEnabled,
+      environments: [
+        {
+          deploymentEnvironmentId: "Environments-7",
+          rolloutPercentage: current.Environments[0].RolloutPercentage,
+        },
+      ],
+    });
+
+    const body = parseToolResponse<{ success: boolean; noOp: boolean }>(response);
+    expect(body.success).toBe(true);
+    expect(body.noOp).toBe(true);
+    expect(doUpdate).not.toHaveBeenCalled();
+  });
+
+  it("merges per-environment patches and preserves unmentioned envs and fields", async () => {
+    const { server } = makeServerStub({ elicitation: true });
+    const current = makeToggle();
+    get.mockResolvedValueOnce(current);
+    doUpdate.mockResolvedValueOnce(undefined);
+
+    const response = await updateFeatureToggleHandler(server, {
+      spaceName: "Default",
+      projectId: "Projects-123",
+      slug: "checkout-redesign",
+      environments: [
+        {
+          deploymentEnvironmentId: "Environments-7",
+          rolloutPercentage: 75,
+        },
+      ],
+    });
+
+    expect(doUpdate).toHaveBeenCalledTimes(1);
+    const [path, body, args] = doUpdate.mock.calls[0];
+    expect(path).toBe("~/api/{spaceId}/projects/{projectId}/featuretoggles");
+    expect(args).toEqual({ spaceId: "Spaces-1", projectId: "Projects-123" });
+
+    // Envs-7 patched
+    const env7 = body.Environments.find(
+      (e: { DeploymentEnvironmentId: string }) =>
+        e.DeploymentEnvironmentId === "Environments-7",
+    );
+    expect(env7.RolloutPercentage).toBe(75);
+    // Other fields on Envs-7 preserved
+    expect(env7.IsEnabled).toBe(true);
+    expect(env7.ClientRolloutPercentage).toBe(50);
+    expect(env7.TenantIds).toEqual(["Tenants-42"]);
+    expect(env7.Segments).toEqual([{ Key: "browser", Value: "Chrome" }]);
+    expect(env7.MinimumVersion).toBe("1.4.0");
+
+    // Envs-8 untouched
+    const env8 = body.Environments.find(
+      (e: { DeploymentEnvironmentId: string }) =>
+        e.DeploymentEnvironmentId === "Environments-8",
+    );
+    expect(env8.RolloutPercentage).toBe(100);
+    expect(env8.IsEnabled).toBe(false);
+
+    // Toggle-level fields preserved
+    expect(body.Name).toBe("checkout-redesign");
+    expect(body.Slug).toBe("checkout-redesign");
+    expect(body.Id).toBe("FeatureToggles-9");
+    expect(body.DefaultIsEnabled).toBe(false);
+    expect(body.Description).toBe("Old description");
+    expect(body.Tags).toEqual(["release-rings/beta"]);
+
+    // Success response
+    const respBody = parseToolResponse<{ success: boolean; resourceUri: string }>(
+      response,
+    );
+    expect(respBody.success).toBe(true);
+    expect(respBody.resourceUri).toBe(
+      "octopus://spaces/Default/projects/Projects-123/featuretoggles/checkout-redesign",
+    );
+  });
+
+  it("applies toggle-level patches (defaultIsEnabled, description) without touching environments", async () => {
+    const { server } = makeServerStub({ elicitation: true });
+    const current = makeToggle();
+    get.mockResolvedValueOnce(current);
+    doUpdate.mockResolvedValueOnce(undefined);
+
+    await updateFeatureToggleHandler(server, {
+      spaceName: "Default",
+      projectId: "Projects-123",
+      slug: "checkout-redesign",
+      defaultIsEnabled: true,
+      description: "Updated description",
+    });
+
+    const [, body] = doUpdate.mock.calls[0];
+    expect(body.DefaultIsEnabled).toBe(true);
+    expect(body.Description).toBe("Updated description");
+    // Environments untouched
+    expect(body.Environments).toEqual(current.Environments);
+  });
+
+  it("aborts when the user declines elicitation", async () => {
+    const { server, elicitInput } = makeServerStub({
+      elicitation: true,
+      elicitResult: { action: "decline" },
+    });
+    get.mockResolvedValueOnce(makeToggle());
+
+    const response = await updateFeatureToggleHandler(server, {
+      spaceName: "Default",
+      projectId: "Projects-123",
+      slug: "checkout-redesign",
+      defaultIsEnabled: true,
+    });
+
+    expect(elicitInput).toHaveBeenCalledTimes(1);
+    expect(doUpdate).not.toHaveBeenCalled();
+    const body = parseToolResponse<{ success: boolean; cancelled: boolean }>(
+      response,
+    );
+    expect(body.success).toBe(false);
+    expect(body.cancelled).toBe(true);
+  });
+
+  it("returns confirmationRequired when client lacks elicitation and confirm is omitted", async () => {
+    const { server } = makeServerStub({ elicitation: false });
+    get.mockResolvedValueOnce(makeToggle());
+
+    const response = await updateFeatureToggleHandler(server, {
+      spaceName: "Default",
+      projectId: "Projects-123",
+      slug: "checkout-redesign",
+      defaultIsEnabled: true,
+    });
+
+    assertToolResponse(response);
+    expect(response.isError).toBe(true);
+    const body = JSON.parse(response.content[0].text);
+    expect(body.confirmationRequired).toBe(true);
+    expect(doUpdate).not.toHaveBeenCalled();
+  });
+
+  it("proceeds without elicitation when confirm: true is supplied as fallback", async () => {
+    const { server, elicitInput } = makeServerStub({ elicitation: false });
+    get.mockResolvedValueOnce(makeToggle());
+    doUpdate.mockResolvedValueOnce(undefined);
+
+    const response = await updateFeatureToggleHandler(server, {
+      spaceName: "Default",
+      projectId: "Projects-123",
+      slug: "checkout-redesign",
+      defaultIsEnabled: true,
+      confirm: true,
+    });
+
+    expect(elicitInput).not.toHaveBeenCalled();
+    expect(doUpdate).toHaveBeenCalledTimes(1);
+    const body = parseToolResponse<{ success: boolean }>(response);
+    expect(body.success).toBe(true);
+  });
+
+  it("translates a 404 from the GET into the disabled-capability hint", async () => {
+    const { server } = makeServerStub({ elicitation: true });
+    get.mockRejectedValueOnce(new Error("Not found (404)"));
+
+    await expect(
+      updateFeatureToggleHandler(server, {
+        spaceName: "Default",
+        projectId: "Projects-123",
+        slug: "missing",
+        defaultIsEnabled: true,
+      }),
+    ).rejects.toThrow(/not found in space 'Default'/);
+  });
+});

--- a/src/tools/findFeatureToggles.ts
+++ b/src/tools/findFeatureToggles.ts
@@ -73,8 +73,19 @@ const findFeatureTogglesSchema = z.object({
     .describe(
       "Filter by environment IDs (e.g. Environments-7). A toggle matches if it has configuration for any of these environments.",
     ),
-  skip: z.number().optional().describe("Pagination offset (≥ 0)."),
-  take: z.number().optional().describe("Pagination page size (≤ 100)."),
+  skip: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Pagination offset (≥ 0)."),
+  take: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe("Pagination page size (1–100, server-side cap)."),
 });
 
 export type FindFeatureTogglesParams = z.infer<typeof findFeatureTogglesSchema>;

--- a/src/tools/findFeatureToggles.ts
+++ b/src/tools/findFeatureToggles.ts
@@ -164,4 +164,5 @@ registerToolDefinition({
   toolName: "find_feature_toggles",
   config: { toolset: "featureToggles", readOnly: true },
   registerFn: registerFindFeatureTogglesTool,
+  minimumOctopusVersion: "2026.1.10655",
 });

--- a/src/tools/findFeatureToggles.ts
+++ b/src/tools/findFeatureToggles.ts
@@ -1,0 +1,167 @@
+import {
+  Client,
+  resolveSpaceId,
+  type ResourceCollection,
+} from "@octopusdeploy/api-client";
+import { z } from "zod";
+import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
+import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
+import {
+  handleOctopusApiError,
+  isErrorWithMessage,
+} from "../helpers/errorHandling.js";
+import {
+  type FeatureToggleResource,
+  type FeatureToggleEnvironmentResource,
+} from "../types/featureToggleTypes.js";
+
+/**
+ * Slim per-environment shape returned alongside each toggle. Includes just
+ * enough state to answer "where is X turned on, and at what rollout?" without
+ * dereferencing the full toggle body. Tenant lists, segments, and minimum
+ * versions stay in the resource.
+ */
+function environmentSummary(env: FeatureToggleEnvironmentResource) {
+  return {
+    deploymentEnvironmentId: env.DeploymentEnvironmentId,
+    isEnabled: env.IsEnabled,
+    rolloutPercentage: env.RolloutPercentage,
+    clientRolloutPercentage: env.ClientRolloutPercentage,
+  };
+}
+
+function toggleSummary(toggle: FeatureToggleResource, spaceName: string) {
+  const encodedSpace = encodeURIComponent(spaceName);
+  const encodedProjectId = encodeURIComponent(toggle.ProjectId);
+  const encodedSlug = encodeURIComponent(toggle.Slug);
+
+  return {
+    id: toggle.Id,
+    slug: toggle.Slug,
+    name: toggle.Name,
+    projectId: toggle.ProjectId,
+    defaultIsEnabled: toggle.DefaultIsEnabled,
+    rolloutGroupId: toggle.RolloutGroupId ?? null,
+    tags: toggle.Tags ?? [],
+    environmentSummaries: (toggle.Environments ?? []).map(environmentSummary),
+    resourceUri: `octopus://spaces/${encodedSpace}/projects/${encodedProjectId}/featuretoggles/${encodedSlug}`,
+  };
+}
+
+const findFeatureTogglesSchema = z.object({
+  spaceName: z.string().describe("Space name."),
+  projectId: z
+    .string()
+    .describe(
+      "Project ID (e.g. Projects-123). Feature toggles are scoped per project.",
+    ),
+  partialName: z
+    .string()
+    .optional()
+    .describe("Case-insensitive substring match on the toggle name."),
+  tags: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Filter by canonical tag names (e.g. "release-rings/beta"). Repeats: a toggle matches if it has any of these tags.',
+    ),
+  environmentIds: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Filter by environment IDs (e.g. Environments-7). A toggle matches if it has configuration for any of these environments.",
+    ),
+  skip: z.number().optional().describe("Pagination offset (≥ 0)."),
+  take: z.number().optional().describe("Pagination page size (≤ 100)."),
+});
+
+export type FindFeatureTogglesParams = z.infer<typeof findFeatureTogglesSchema>;
+
+export async function findFeatureTogglesHandler(
+  params: FindFeatureTogglesParams,
+) {
+  const { spaceName, projectId, partialName, tags, environmentIds, skip, take } =
+    params;
+
+  const client = await Client.create(getClientConfigurationFromEnvironment());
+
+  let spaceId: string;
+  try {
+    spaceId = await resolveSpaceId(client, spaceName);
+  } catch (error) {
+    handleOctopusApiError(error, { spaceName });
+  }
+
+  try {
+    const response = await client.get<ResourceCollection<FeatureToggleResource>>(
+      "~/api/{spaceId}/projects/{projectId}/featuretoggles{?Skip,Take,PartialName,Tags,Environments}",
+      {
+        spaceId,
+        projectId,
+        Skip: skip,
+        Take: take,
+        PartialName: partialName,
+        Tags: tags,
+        Environments: environmentIds,
+      },
+    );
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            totalResults: response.TotalResults,
+            itemsPerPage: response.ItemsPerPage,
+            numberOfPages: response.NumberOfPages,
+            lastPageNumber: response.LastPageNumber,
+            items: (response.Items ?? []).map((toggle) =>
+              toggleSummary(toggle, spaceName),
+            ),
+          }),
+        },
+      ],
+    };
+  } catch (error) {
+    // 404 at this layer is ambiguous: either feature toggles are disabled on
+    // the instance (per the API contract — every route returns 404 when the
+    // capability is off), or the projectId is wrong. The space itself was
+    // already resolved successfully above. Surface the disabled-capability
+    // hint rather than the generic "Space not found" message.
+    if (isErrorWithMessage(error, "not found") || isErrorWithMessage(error, "404")) {
+      throw new Error(
+        `Feature toggles endpoint returned 404 for project '${projectId}' in space '${spaceName}'. ` +
+          "Either the customer feature toggles capability is disabled on this Octopus instance, or the projectId is incorrect. " +
+          "Use list_projects to verify the project ID.",
+      );
+    }
+    handleOctopusApiError(error, { spaceName });
+  }
+}
+
+export function registerFindFeatureTogglesTool(server: McpServer) {
+  server.registerTool(
+    "find_feature_toggles",
+    {
+      title: "Find feature toggles",
+      description: `List customer feature toggles in an Octopus Deploy project.
+
+Each summary includes per-environment state (isEnabled, rolloutPercentage, clientRolloutPercentage) so "where is X turned on" is answerable from the list response. Heavy fields (description, tenant lists, segments, minimum versions) live in the resource body.
+
+Dereference the returned resourceUri (octopus://spaces/{spaceName}/projects/{projectId}/featuretoggles/{slug}) for the full toggle body.
+
+Use update_feature_toggle to flip an environment on/off or change rollout percentages on an existing toggle. This MCP server does not expose toggle creation, deletion, renaming, or rollout-group management — direct customers to the Octopus UI for those.`,
+      inputSchema: findFeatureTogglesSchema.shape,
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
+    },
+    findFeatureTogglesHandler,
+  );
+}
+
+registerToolDefinition({
+  toolName: "find_feature_toggles",
+  config: { toolset: "featureToggles", readOnly: true },
+  registerFn: registerFindFeatureTogglesTool,
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -30,6 +30,10 @@ import "./findCertificates.js";
 import "./findAccounts.js";
 import "./findInterruptions.js";
 
+// Feature toggles
+import "./findFeatureToggles.js";
+import "./updateFeatureToggle.js";
+
 // Write operations
 import "./createRelease.js";
 import "./deployRelease.js";

--- a/src/tools/updateFeatureToggle.ts
+++ b/src/tools/updateFeatureToggle.ts
@@ -40,37 +40,61 @@ const environmentPatchSchema = z.object({
     .describe("Client-side fractional rollout evaluated by the SDK [0, 100]."),
 });
 
-const updateFeatureToggleSchema = z.object({
-  spaceName: z.string().describe("Space name."),
-  projectId: z
-    .string()
-    .describe("Project ID (e.g. Projects-123). Feature toggles are scoped per project."),
-  slug: z
-    .string()
-    .describe("The toggle's Slug (not its Id). Find it via find_feature_toggles."),
-  defaultIsEnabled: z
-    .boolean()
-    .optional()
-    .describe(
-      "Toggle-level default. The value returned for environments that have no explicit per-environment configuration.",
-    ),
-  description: z
-    .string()
-    .optional()
-    .describe("Toggle-level description (max 1000 chars). Markdown supported in the UI."),
-  environments: z
-    .array(environmentPatchSchema)
-    .optional()
-    .describe(
-      "Per-environment patches. Environments not listed here are preserved as-is. Each entry must reference a deploymentEnvironmentId that already exists on the toggle; unknown environments are rejected rather than silently added.",
-    ),
-  confirm: z
-    .boolean()
-    .optional()
-    .describe(
-      "Required only when the MCP client does not support elicitation. Set to true to confirm the update; otherwise the tool aborts.",
-    ),
-});
+export const updateFeatureToggleSchema = z
+  .object({
+    spaceName: z.string().describe("Space name."),
+    projectId: z
+      .string()
+      .describe("Project ID (e.g. Projects-123). Feature toggles are scoped per project."),
+    slug: z
+      .string()
+      .describe("The toggle's Slug (not its Id). Find it via find_feature_toggles."),
+    defaultIsEnabled: z
+      .boolean()
+      .optional()
+      .describe(
+        "Toggle-level default. The value returned for environments that have no explicit per-environment configuration.",
+      ),
+    description: z
+      .string()
+      .optional()
+      .describe("Toggle-level description (max 1000 chars). Markdown supported in the UI."),
+    environments: z
+      .array(environmentPatchSchema)
+      .optional()
+      .describe(
+        "Per-environment patches. Environments not listed here are preserved as-is. Each entry must reference a deploymentEnvironmentId that already exists on the toggle; unknown environments are rejected rather than silently added. Each environment may appear at most once in this array — duplicates are rejected.",
+      ),
+    confirm: z
+      .boolean()
+      .optional()
+      .describe(
+        "Required only when the MCP client does not support elicitation. Set to true to confirm the update; otherwise the tool aborts.",
+      ),
+  })
+  .superRefine((args, ctx) => {
+    // Reject duplicate deploymentEnvironmentIds up front. Without this,
+    // the merge picks the FIRST patch for the env while the confirmation
+    // diff overwrites earlier entries with later ones using the same key —
+    // the user could see one change in the prompt and a different one
+    // actually go through.
+    if (!args.environments) return;
+    const seen = new Map<string, number>();
+    for (let i = 0; i < args.environments.length; i++) {
+      const id = args.environments[i].deploymentEnvironmentId;
+      const prev = seen.get(id);
+      if (prev !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            `Duplicate environment entry for '${id}' at index ${i} (also at index ${prev}). ` +
+            "Combine the patches into a single entry per environment.",
+          path: ["environments", i, "deploymentEnvironmentId"],
+        });
+      }
+      seen.set(id, i);
+    }
+  });
 
 export type UpdateFeatureToggleParams = z.infer<typeof updateFeatureToggleSchema>;
 
@@ -366,7 +390,7 @@ Narrow surface — flip an environment on/off, change rollout percentages, or up
 Deliberately not exposed: name/slug rename, tag changes, rollout group attach/detach, tenant targeting, segments, minimum version, adding or removing environment configurations entirely. For those, use the Octopus UI.
 
 Patches that reference an environment not already configured on the toggle are rejected with reason: environment_not_configured. The tool does not add new environment configurations.`,
-      inputSchema: updateFeatureToggleSchema.shape,
+      inputSchema: updateFeatureToggleSchema,
       annotations: DESTRUCTIVE_WRITE_TOOL_ANNOTATIONS,
     },
     (args) => updateFeatureToggleHandler(server, args),

--- a/src/tools/updateFeatureToggle.ts
+++ b/src/tools/updateFeatureToggle.ts
@@ -377,4 +377,5 @@ registerToolDefinition({
   toolName: "update_feature_toggle",
   config: { toolset: "featureToggles", readOnly: false },
   registerFn: registerUpdateFeatureToggleTool,
+  minimumOctopusVersion: "2026.1.10655",
 });

--- a/src/tools/updateFeatureToggle.ts
+++ b/src/tools/updateFeatureToggle.ts
@@ -1,0 +1,380 @@
+import { Client, resolveSpaceId } from "@octopusdeploy/api-client";
+import { z } from "zod";
+import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
+import { registerToolDefinition } from "../types/toolConfig.js";
+import { DESTRUCTIVE_WRITE_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
+import { handleOctopusApiError } from "../helpers/errorHandling.js";
+import {
+  requireConfirmation,
+  unconfirmedResponse,
+} from "../helpers/requireConfirmation.js";
+import {
+  type FeatureToggleResource,
+  type FeatureToggleEnvironmentResource,
+} from "../types/featureToggleTypes.js";
+
+const environmentPatchSchema = z.object({
+  deploymentEnvironmentId: z
+    .string()
+    .describe(
+      "Targets the existing per-environment configuration to patch (e.g. Environments-7). Must already be configured on the toggle — this tool does not add new environment configurations.",
+    ),
+  isEnabled: z
+    .boolean()
+    .optional()
+    .describe("Whether the toggle is on for this environment, before targeting/rollout is applied."),
+  rolloutPercentage: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe("Server-side rollout percentage [0, 100]."),
+  clientRolloutPercentage: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe("Client-side fractional rollout evaluated by the SDK [0, 100]."),
+});
+
+const updateFeatureToggleSchema = z.object({
+  spaceName: z.string().describe("Space name."),
+  projectId: z
+    .string()
+    .describe("Project ID (e.g. Projects-123). Feature toggles are scoped per project."),
+  slug: z
+    .string()
+    .describe("The toggle's Slug (not its Id). Find it via find_feature_toggles."),
+  defaultIsEnabled: z
+    .boolean()
+    .optional()
+    .describe(
+      "Toggle-level default. The value returned for environments that have no explicit per-environment configuration.",
+    ),
+  description: z
+    .string()
+    .optional()
+    .describe("Toggle-level description (max 1000 chars). Markdown supported in the UI."),
+  environments: z
+    .array(environmentPatchSchema)
+    .optional()
+    .describe(
+      "Per-environment patches. Environments not listed here are preserved as-is. Each entry must reference a deploymentEnvironmentId that already exists on the toggle; unknown environments are rejected rather than silently added.",
+    ),
+  confirm: z
+    .boolean()
+    .optional()
+    .describe(
+      "Required only when the MCP client does not support elicitation. Set to true to confirm the update; otherwise the tool aborts.",
+    ),
+});
+
+export type UpdateFeatureToggleParams = z.infer<typeof updateFeatureToggleSchema>;
+
+interface PatchedEnvironment {
+  current: FeatureToggleEnvironmentResource;
+  merged: FeatureToggleEnvironmentResource;
+  changedFields: string[];
+}
+
+function applyEnvironmentPatch(
+  current: FeatureToggleEnvironmentResource,
+  patch: z.infer<typeof environmentPatchSchema>,
+): PatchedEnvironment {
+  const merged: FeatureToggleEnvironmentResource = { ...current };
+  const changedFields: string[] = [];
+
+  if (patch.isEnabled !== undefined && patch.isEnabled !== current.IsEnabled) {
+    merged.IsEnabled = patch.isEnabled;
+    changedFields.push("IsEnabled");
+  }
+  if (
+    patch.rolloutPercentage !== undefined &&
+    patch.rolloutPercentage !== current.RolloutPercentage
+  ) {
+    merged.RolloutPercentage = patch.rolloutPercentage;
+    changedFields.push("RolloutPercentage");
+  }
+  if (
+    patch.clientRolloutPercentage !== undefined &&
+    patch.clientRolloutPercentage !== current.ClientRolloutPercentage
+  ) {
+    merged.ClientRolloutPercentage = patch.clientRolloutPercentage;
+    changedFields.push("ClientRolloutPercentage");
+  }
+
+  return { current, merged, changedFields };
+}
+
+function buildDiffSource(
+  toggle: FeatureToggleResource,
+  params: UpdateFeatureToggleParams,
+  envPatches: PatchedEnvironment[],
+): Record<string, unknown> {
+  const source: Record<string, unknown> = {};
+  if (params.defaultIsEnabled !== undefined) {
+    source.DefaultIsEnabled = toggle.DefaultIsEnabled;
+  }
+  if (params.description !== undefined) {
+    source.Description = toggle.Description ?? null;
+  }
+  for (const patch of envPatches) {
+    if (patch.changedFields.length === 0) continue;
+    const sourceFields: Record<string, unknown> = {};
+    for (const field of patch.changedFields) {
+      sourceFields[field] =
+        patch.current[field as keyof FeatureToggleEnvironmentResource];
+    }
+    source[`Environments[${patch.current.DeploymentEnvironmentId}]`] = sourceFields;
+  }
+  return source;
+}
+
+function buildDiffTarget(
+  params: UpdateFeatureToggleParams,
+  envPatches: PatchedEnvironment[],
+): Record<string, unknown> {
+  const target: Record<string, unknown> = {};
+  if (params.defaultIsEnabled !== undefined) {
+    target.DefaultIsEnabled = params.defaultIsEnabled;
+  }
+  if (params.description !== undefined) {
+    target.Description = params.description;
+  }
+  for (const patch of envPatches) {
+    if (patch.changedFields.length === 0) continue;
+    const targetFields: Record<string, unknown> = {};
+    for (const field of patch.changedFields) {
+      targetFields[field] =
+        patch.merged[field as keyof FeatureToggleEnvironmentResource];
+    }
+    target[`Environments[${patch.current.DeploymentEnvironmentId}]`] = targetFields;
+  }
+  return target;
+}
+
+export async function updateFeatureToggleHandler(
+  server: McpServer,
+  params: UpdateFeatureToggleParams,
+) {
+  const { spaceName, projectId, slug, environments, confirm } = params;
+
+  const noPatches =
+    params.defaultIsEnabled === undefined &&
+    params.description === undefined &&
+    (!environments || environments.length === 0);
+  if (noPatches) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              success: false,
+              reason: "no_patches",
+              message:
+                "No fields supplied to update. Pass at least one of defaultIsEnabled, description, or environments[].",
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const client = await Client.create(getClientConfigurationFromEnvironment());
+
+  let spaceId: string;
+  try {
+    spaceId = await resolveSpaceId(client, spaceName);
+  } catch (error) {
+    handleOctopusApiError(error, { spaceName });
+  }
+
+  let current: FeatureToggleResource;
+  try {
+    current = await client.get<FeatureToggleResource>(
+      "~/api/{spaceId}/projects/{projectId}/featuretoggles/{slug}",
+      { spaceId, projectId, slug },
+    );
+  } catch (error) {
+    handleOctopusApiError(error, {
+      entityType: "feature toggle",
+      entityId: slug,
+      spaceName,
+      helpText:
+        "Use find_feature_toggles to list valid slugs. If 404 persists across all toggles in the project, the customer feature toggles capability may be disabled on the Octopus instance.",
+    });
+  }
+
+  // Match patch entries to existing environment configurations. Unknown
+  // environments are rejected — the contract is "slight adjustment", not
+  // "configure new environments".
+  const envPatches: PatchedEnvironment[] = [];
+  if (environments) {
+    for (const patch of environments) {
+      const existing = current.Environments.find(
+        (e) => e.DeploymentEnvironmentId === patch.deploymentEnvironmentId,
+      );
+      if (!existing) {
+        const configured = current.Environments.map(
+          (e) => e.DeploymentEnvironmentId,
+        );
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: false,
+                  reason: "environment_not_configured",
+                  message:
+                    `Environment '${patch.deploymentEnvironmentId}' is not configured on toggle '${current.Slug}'. ` +
+                    "This tool only adjusts existing environment configurations; it does not add new ones. " +
+                    "Use the Octopus UI to add an environment to a toggle.",
+                  configuredEnvironmentIds: configured,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+          isError: true,
+        };
+      }
+      envPatches.push(applyEnvironmentPatch(existing, patch));
+    }
+  }
+
+  // Detect a no-op call (everything provided already matches current state)
+  // before involving the user with a confirmation dialog.
+  const toggleLevelChanges =
+    (params.defaultIsEnabled !== undefined &&
+      params.defaultIsEnabled !== current.DefaultIsEnabled) ||
+    (params.description !== undefined &&
+      params.description !== (current.Description ?? undefined));
+  const envLevelChanges = envPatches.some((p) => p.changedFields.length > 0);
+  if (!toggleLevelChanges && !envLevelChanges) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              success: true,
+              noOp: true,
+              message:
+                "All supplied fields already match the current toggle state — nothing to update.",
+              slug: current.Slug,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  }
+
+  const merged: FeatureToggleResource = {
+    ...current,
+    DefaultIsEnabled:
+      params.defaultIsEnabled !== undefined
+        ? params.defaultIsEnabled
+        : current.DefaultIsEnabled,
+    Description:
+      params.description !== undefined ? params.description : current.Description,
+    Environments: current.Environments.map((env) => {
+      const patch = envPatches.find(
+        (p) => p.current.DeploymentEnvironmentId === env.DeploymentEnvironmentId,
+      );
+      return patch ? patch.merged : env;
+    }),
+  };
+
+  const confirmation = await requireConfirmation(server, {
+    message: `Update feature toggle "${current.Name}" (${current.Slug}) in space ${spaceName}?`,
+    fallbackConfirm: confirm,
+    change: {
+      source: buildDiffSource(current, params, envPatches),
+      target: buildDiffTarget(params, envPatches),
+    },
+  });
+  if (!confirmation.confirmed) {
+    return unconfirmedResponse(confirmation, {
+      action: "feature toggle update",
+    });
+  }
+
+  try {
+    await client.doUpdate<FeatureToggleResource>(
+      "~/api/{spaceId}/projects/{projectId}/featuretoggles",
+      merged,
+      { spaceId, projectId },
+    );
+  } catch (error) {
+    handleOctopusApiError(error, {
+      entityType: "feature toggle",
+      entityId: current.Id,
+      spaceName,
+      helpText:
+        "Verify you have FeatureToggleEdit on the project and every environment referenced. Server-side validation rules (max segments, ephemeral environment clamping, etc.) are documented in the Octopus feature toggles API reference.",
+    });
+  }
+
+  const encodedSpace = encodeURIComponent(spaceName);
+  const encodedProjectId = encodeURIComponent(projectId);
+  const encodedSlug = encodeURIComponent(current.Slug);
+  const resourceUri = `octopus://spaces/${encodedSpace}/projects/${encodedProjectId}/featuretoggles/${encodedSlug}`;
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            success: true,
+            id: current.Id,
+            slug: current.Slug,
+            name: current.Name,
+            resourceUri,
+            message: `Feature toggle '${current.Slug}' updated successfully.`,
+            helpText:
+              "Dereference resourceUri to read the updated toggle body.",
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+export function registerUpdateFeatureToggleTool(server: McpServer) {
+  server.registerTool(
+    "update_feature_toggle",
+    {
+      title: "Update a feature toggle",
+      description: `Adjust an existing customer feature toggle in an Octopus Deploy project.
+
+Narrow surface — flip an environment on/off, change rollout percentages, or update the toggle-level description / default state. Internally fetches the current toggle, applies your patches in memory, and PUTs the merged body, so unmentioned environments and unmentioned fields are preserved.
+
+Deliberately not exposed: name/slug rename, tag changes, rollout group attach/detach, tenant targeting, segments, minimum version, adding or removing environment configurations entirely. For those, use the Octopus UI.
+
+Patches that reference an environment not already configured on the toggle are rejected with reason: environment_not_configured. The tool does not add new environment configurations.`,
+      inputSchema: updateFeatureToggleSchema.shape,
+      annotations: DESTRUCTIVE_WRITE_TOOL_ANNOTATIONS,
+    },
+    (args) => updateFeatureToggleHandler(server, args),
+  );
+}
+
+registerToolDefinition({
+  toolName: "update_feature_toggle",
+  config: { toolset: "featureToggles", readOnly: false },
+  registerFn: registerUpdateFeatureToggleTool,
+});

--- a/src/types/featureToggleTypes.ts
+++ b/src/types/featureToggleTypes.ts
@@ -1,0 +1,43 @@
+/**
+ * Wire-format types for the customer-facing Feature Toggles API.
+ *
+ * Octopus's @octopusdeploy/api-client (3.8.0) does not expose typed Repository
+ * classes or Resource interfaces for feature toggles, so we declare the minimum
+ * surface we touch here. Field names and casing match the JSON response from
+ * /api/{spaceId}/projects/{projectId}/featuretoggles{,/{slug}}.
+ */
+
+export interface FeatureToggleEnvironmentResource {
+  FeatureToggleId?: string;
+  DeploymentEnvironmentId: string;
+  IsEnabled: boolean;
+  RolloutPercentage?: number;
+  ClientRolloutPercentage?: number;
+  TenantIds?: string[];
+  ExcludedTenantIds?: string[];
+  TenantTags?: string[];
+  ExcludedTenantTags?: string[];
+  Segments?: Array<{ Key: string; Value: string }>;
+  MinimumVersion?: string | null;
+}
+
+export interface FeatureToggleResource {
+  Id: string;
+  SpaceId: string;
+  ProjectId: string;
+  Name: string;
+  Slug: string;
+  DefaultIsEnabled: boolean;
+  Description?: string | null;
+  Environments: FeatureToggleEnvironmentResource[];
+  Tags: string[];
+  RolloutGroupId?: string | null;
+}
+
+export interface RolloutGroupResource {
+  Id: string;
+  SpaceId: string;
+  ProjectId: string;
+  Name: string;
+  FeatureToggleUsages: Array<{ Id: string; Name: string }>;
+}

--- a/src/types/toolConfig.ts
+++ b/src/types/toolConfig.ts
@@ -13,7 +13,8 @@ export type Toolset =
   | "context"
   | "certificates"
   | "accounts"
-  | "interruptions";
+  | "interruptions"
+  | "featureToggles";
 
 export interface ToolConfig {
   toolset: Toolset;
@@ -51,7 +52,8 @@ export const DEFAULT_TOOLSETS: Toolset[] = [
   "context",
   "certificates",
   "accounts",
-  "interruptions"
+  "interruptions",
+  "featureToggles"
 ];
 
 export interface ToolVersionInfo {


### PR DESCRIPTION
## Summary

Surface the customer-facing [Feature Toggles API](https://octopus.com/docs/) through the MCP server with a narrow read+adjust interface. Customers can list toggles in a project, see per-environment state at a glance, and flip enablement or rollout percentages on existing toggles via Claude / other MCP clients.

Two tools, two resources, all in a new `featureToggles` toolset:

| Surface | Behavior |
|---|---|
| `find_feature_toggles` | Lists toggles in a project. Slim summaries include per-environment `isEnabled` / `rolloutPercentage` / `clientRolloutPercentage` plus a `resourceUri` so "where is X turned on" is answerable from the list response. |
| `update_feature_toggle` | Adjusts an existing toggle. Fetches current state, applies patches in memory, PUTs the merged body — unmentioned environments and unmentioned fields are preserved. |
| `octopus://spaces/{n}/projects/{p}/featuretoggles/{slug}` | Full toggle body resource (description, tenants, segments, minimum versions). |
| `octopus://spaces/{n}/projects/{p}/rolloutgroups/{id}` | Read-only rollout group resource for inspection only. |

Both tools are marked `minimumOctopusVersion: "2026.1.10655"` (the version that ships the customer-facing feature toggles API). The version is metadata for `--list-tools-by-version` reporting; following the project convention it is not enforced at runtime.

## Out of scope (deliberate)

By design, this MCP server does **not** expose toggle creation, deletion, renaming, retagging, rollout-group writes, attaching/detaching rollout groups, tenant targeting, segments, minimum-version filters, or SDK client-identifier generation/rotation. Direct customers to the Octopus UI for those — they're the operations a misbehaving LLM could most easily turn into incidents.

## Notable design choices

- **Patch-merge instead of full PUT.** The Octopus PUT endpoint replaces the entire toggle body (omitted environments are removed). Handing the LLM that loaded weapon would let one bad request wipe a toggle's configuration. Instead `update_feature_toggle` does fetch → patch in memory → PUT, with patches matched by `deploymentEnvironmentId`.
- **Unknown environments rejected.** Patches that reference an env not currently configured on the toggle return `reason: "environment_not_configured"` rather than silently adding new env configs. Keeps the "slight adjustment" contract honest.
- **`DESTRUCTIVE_WRITE_TOOL_ANNOTATIONS`** on the update tool. Even though the merge is conservative, the underlying PUT mutates live state, and clients should confirm before running. Confirmation message includes a diff (via `requireConfirmation`'s `change` argument) so elicitation-capable clients can show what's actually changing.
- **No api-client support.** `@octopusdeploy/api-client` 3.8.0 has no `FeatureToggleRepository`, so calls go through the low-level `client.get` / `client.doUpdate` with `~/api/{spaceId}/...` route templates — same pattern as `findInterruptions.ts`.
- **Custom 404 handling on the listing endpoint.** The standard `handleOctopusApiError` would render a 404 here as "Space not found", but the space was already resolved successfully — a 404 at this layer means either the project ID is wrong or the customer feature toggles capability is disabled on the instance. Surface that hint instead.
- **`execute` backstop allowlist.** After merging main, added a `featureToggles` entry to `pathAllowlist.ts` so the new toolset is reachable through `execute` (subject to the same method-tier gating as everything else).

## Reviewer notes

- New `featureToggles` toolset added to `Toolset` union and `DEFAULT_TOOLSETS` — clients can disable the whole surface with `--toolsets <other>`.
- 8 new unit tests focused on logic unique to this PR (slim-summary mapping, PascalCase URI-template params, the custom 404 hint, patch-merge correctness, unknown-env rejection, one elicitation-integration test per write tool, and route-template + stripLinks for each resource). The full confirmation-outcome matrix, generic 404/401 translation, and entity-ID validation are covered by shared-helper test files (`requireConfirmation.test.ts` etc.) and not duplicated here.
- Field types are declared in `src/types/featureToggleTypes.ts` since the api-client doesn't expose them.
- Branch was merged with main to pick up the `execute` backstop / catalog work; the merge required a `featureToggles` entry in the new `pathAllowlist.ts` Record.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm test` (unit) — 158/158 passing including 8 new tests
- [ ] End-to-end against a real Octopus instance with feature toggles enabled (requires test instance — needs product confirmation before running)
  - [ ] `find_feature_toggles` returns slim list with env summaries populated
  - [ ] `read_resource` on a returned `octopus://...featuretoggles/{slug}` URI returns the full body
  - [ ] `update_feature_toggle` with `{ slug, environments: [{ deploymentEnvironmentId, rolloutPercentage: 75 }] }` updates only that env's percentage; other envs untouched
  - [ ] `update_feature_toggle` against an env not configured on the toggle → `environment_not_configured` error, no PUT issued
  - [ ] `update_feature_toggle` with declined elicitation → no PUT
  - [ ] 403 surfaced cleanly when API key lacks `FeatureToggleEdit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)