### PR TITLE
feat: invert read-only flag — writes enabled by default, --read-only opts out

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ We are planning to release a native ARM build shortly so that those arguments wi
 
 Full example configuration (for Claude Desktop, Claude Code, and Cursor):
 
-**Read-only mode (default, recommended for production):**
+**Write tools enabled (default):**
 ```json
 {
   "mcpServers": {
@@ -88,14 +88,14 @@ Full example configuration (for Claude Desktop, Claude Code, and Cursor):
 }
 ```
 
-**Write mode enabled (for development/testing):**
+**Read-only mode (recommended for production):**
 ```json
 {
   "mcpServers": {
     "octopusdeploy": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@octopusdeploy/mcp-server", "--no-read-only"],
+      "args": ["-y", "@octopusdeploy/mcp-server", "--read-only"],
       "env": {
         "OCTOPUS_SERVER_URL": "https://your-octopus.com",
         "OCTOPUS_API_KEY": "YOUR_API_KEY"
@@ -201,7 +201,7 @@ Available toolsets:
 - **context** - Authenticated user and project context (current user, Git branches)
 
 #### Read-Only Mode
-The server runs in read-only mode by default for security. Most tools are read-only operations, but some tools can perform write operations (like creating releases and deployments).
+The server runs with write tools enabled by default. Pass `--read-only` to disable all write tools and block POST/PUT/PATCH/DELETE through the `execute` backstop. Most curated tools are already read-only; only a small set perform writes.
 
 **Write-enabled tools (always-write):**
 - `create_release` - Create new releases
@@ -216,21 +216,21 @@ Write tools are gated by an MCP elicitation prompt: clients that support elicita
 The server uses a three-tier read/write/delete classification, enforced server-side based on the HTTP method (the agent cannot bypass this by lying about intent):
 
 - **read** — always allowed. GET requests through `execute`, plus all `find_*` / `get_*` / `list_*` tools.
-- **write** — POST/PUT/PATCH through `execute` and the always-write tools above. Requires `--no-read-only`.
-- **delete** — DELETE through `execute`. Requires `--no-read-only` AND `--allow-deletes` (a deliberate two-flag opt-in for irreversible operations). A small set of catastrophic-delete paths (e.g. `DELETE /api/spaces/{id}`, `DELETE /api/users/{id}`) and API-key endpoints are on a hard sensitive denylist that ignores both flags.
+- **write** — POST/PUT/PATCH through `execute` and the always-write tools above. Blocked when `--read-only` is set.
+- **delete** — DELETE through `execute`. Requires `--allow-deletes` and is blocked when `--read-only` is set. A small set of catastrophic-delete paths (e.g. `DELETE /api/spaces/{id}`, `DELETE /api/users/{id}`) and API-key endpoints are on a hard sensitive denylist that ignores both flags.
 
 ```bash
-# Run in read-only mode (default) - write/delete tools are disabled
+# Default - write tools enabled (POST/PUT/PATCH)
 npx -y @octopusdeploy/mcp-server
 
-# Disable read-only mode to enable write operations (POST/PUT/PATCH)
-npx -y @octopusdeploy/mcp-server --no-read-only
+# Read-only mode - write/delete tools disabled
+npx -y @octopusdeploy/mcp-server --read-only
 
 # Additionally permit DELETE requests through the execute tool
-npx -y @octopusdeploy/mcp-server --no-read-only --allow-deletes
+npx -y @octopusdeploy/mcp-server --allow-deletes
 ```
 
-**Security Note:** When disabling read-only mode, ensure you use an API key with appropriate, least-privilege permissions. Write operations can create releases and trigger deployments in your Octopus instance. `--allow-deletes` is off by default; only enable it when the agent must issue DELETE requests through `execute`. If you pass `--allow-deletes` without `--no-read-only`, the server prints a startup warning to stderr — DELETE requests still go through the read-only gate first and remain blocked.
+**Security Note:** Use an API key with appropriate, least-privilege permissions — write operations can create releases and trigger deployments in your Octopus instance. For production, consider passing `--read-only` unless you have a specific, controlled use case for writes. `--allow-deletes` is off by default; only enable it when the agent must issue DELETE requests through `execute`. If you pass `--allow-deletes` together with `--read-only`, the server prints a startup warning to stderr — DELETE requests remain blocked by the read-only gate.
 
 #### Complete Examples
 
@@ -240,17 +240,17 @@ All examples below assume `OCTOPUS_API_KEY` is set in the environment. The `--se
 # Development setup with only core and project tools
 npx -y @octopusdeploy/mcp-server --toolsets core,projects --server-url https://your-octopus.com
 
-# Full production setup with all tools (read-only by default)
-npx -y @octopusdeploy/mcp-server --toolsets all --server-url https://your-octopus.com
+# Production setup with all tools and read-only enforcement
+npx -y @octopusdeploy/mcp-server --toolsets all --read-only --server-url https://your-octopus.com
 
-# Development setup with write operations enabled
-npx -y @octopusdeploy/mcp-server --no-read-only --server-url https://your-octopus.com
+# Default invocation - all tools and writes enabled
+npx -y @octopusdeploy/mcp-server --server-url https://your-octopus.com
 ```
 
 #### Other command line arguments
 
-* `--no-read-only` - Disable read-only mode, enabling POST/PUT/PATCH through the curated write tools and through `execute`. See [Read-Only Mode](#read-only-mode).
-* `--allow-deletes` - Additionally permit DELETE requests through the `execute` tool. Requires `--no-read-only`. Default `false`.
+* `--read-only` - Enable read-only mode: disable all curated write tools and block POST/PUT/PATCH/DELETE through `execute`. Writes are enabled by default; this flag turns them off. See [Read-Only Mode](#read-only-mode).
+* `--allow-deletes` - Permit DELETE requests through the `execute` tool. Has no effect when `--read-only` is set. Default `false`.
 * `--log-level <level>` - Minimum log level (info, error)
 * `--log-file <path>` - Log file path or filename. If not specified, logs are written to console only
 * `-q, --quiet` - Disable file logging, only log errors to console
@@ -307,15 +307,15 @@ These tools and resources let the agent reach Octopus REST endpoints that don't 
 - `grep_llms_txt`: Search the Octopus API catalog (`octopus://api/llms.txt`) with grep-style semantics (minimum supported Octopus version: `2026.2.3916`). The catalog body is large (typically 300+ KB) — call this rather than reading the resource body directly. Parameters mirror GNU grep (`pattern`, `caseInsensitive`, `invertMatch`, `fixedString`, `beforeContext`, `afterContext`, `maxCount`). Useful for discovering endpoints (`POST /releases`), enumerating delete endpoints (`DELETE `), or finding the body type for a write operation (`Body: Create.*Command`).
 - `execute`: Structured REST backstop. Reaches any Octopus endpoint covered by the per-toolset path allowlist. The HTTP method is the authoritative read/write/delete classifier — never an `isWrite` flag the LLM can set. Method gating is hard-coded server-side:
    - `GET` is always allowed (subject to the path allowlist + sensitive denylist).
-   - `POST`/`PUT`/`PATCH` require `--no-read-only` plus user confirmation via elicitation.
-   - `DELETE` requires `--no-read-only` AND `--allow-deletes` plus a stronger "IRREVERSIBLE" elicitation message.
+   - `POST`/`PUT`/`PATCH` are blocked when `--read-only` is set; otherwise they require user confirmation via elicitation.
+   - `DELETE` requires `--allow-deletes` (and is blocked when `--read-only` is set) plus a stronger "IRREVERSIBLE" elicitation message.
    - The sensitive denylist (API-key endpoints, `DELETE /api/spaces/{id}`, `DELETE /api/users/{id}`) is enforced even with both flags on.
    - The path allowlist is scoped per toolset — disabling a toolset (e.g. `certificates`) makes its paths unreachable through `execute`, even on GET.
 
 Catalog data is also exposed as MCP Resources:
 
 - `octopus://api/llms.txt` — markdown catalog of every Octopus REST endpoint (HTTP method, path, query params, request/response types). Requires Octopus Server `2026.2.3916` or later. 5-minute in-memory cache keyed on the configured server URL. **Prefer `grep_llms_txt` to reading the body directly.**
-- `octopus://api/capabilities` — JSON describing the running session: server version, enabled toolsets, available tools (with their `minimumOctopusVersion`), and whether read-only / `--allow-deletes` mode is on. Useful for the agent to discover what's reachable in this session.
+- `octopus://api/capabilities` — JSON describing the running session: server version, enabled toolsets, available tools (with their `minimumOctopusVersion`), and whether `--read-only` / `--allow-deletes` is on. Useful for the agent to discover what's reachable in this session.
 
 ### Projects
 - `list_projects`: List all projects in a given space
@@ -392,23 +392,23 @@ The Octopus MCP Server includes both read and write operations. Important securi
 - Exercise caution when connecting to tools and models you do not fully trust
 
 ### Write Operations
-When read-only mode is disabled (`--no-read-only`), the following write operations become available:
+By default, the following write operations are available:
 - **Creating releases**: Can create new releases for projects
 - **Deploying releases**: Can trigger deployments to environments (including production)
 - **Running runbooks**: Can execute runbooks against environments and tenants
 - **Updating feature toggles**: Can flip per-environment state and change rollout percentages on existing toggles
 - **Arbitrary POST/PUT/PATCH via the `execute` backstop**: Subject to the per-toolset path allowlist and a sensitive denylist that's always-on.
 
-DELETE requests through `execute` require an additional `--allow-deletes` flag — a deliberate two-flag opt-in for irreversible operations.
+Pass `--read-only` to disable all of the above. DELETE requests through `execute` require an additional `--allow-deletes` flag — a deliberate opt-in for irreversible operations — and remain blocked when `--read-only` is set.
 
 **Critical Security Measures:**
 1. **Least Privilege**: Use API keys with the minimum permissions needed for your use case
-2. **Read-Only by Default**: The server defaults to read-only mode — you must explicitly opt-in to write operations, and again to DELETE.
+2. **Opt In to Read-Only Mode**: Writes are enabled by default. For production, pass `--read-only` unless you have a specific, controlled use case for write operations. DELETE always requires the additional `--allow-deletes` opt-in.
 3. **Method gating is server-side and hard-coded**: The HTTP method passed to `execute` is the authoritative classifier. The agent cannot bypass the gate by misrepresenting what the call does — POST/PUT/PATCH/DELETE requests get tier-specific gating regardless of the prose in the request body.
 4. **Toolset filtering doubles as a kill switch**: Disabling a toolset removes both its curated tools and its paths from the `execute` allowlist.
 5. **Prompt Injection Risk**: Running agents in fully automated fashion could make you vulnerable to prompt-injection attacks
 
-**Recommendation**: For production environments, use read-only mode unless you have a specific, controlled use case for write operations. Leave `--allow-deletes` off unless you specifically need DELETE semantics through `execute`.
+**Recommendation**: For production environments, pass `--read-only` unless you have a specific, controlled use case for write operations. Leave `--allow-deletes` off unless you specifically need DELETE semantics through `execute`.
 
 ## ⚠️ Limitations
 

--- a/src/helpers/methodTier.ts
+++ b/src/helpers/methodTier.ts
@@ -5,8 +5,8 @@
  *
  * Tiers:
  *   - read   → GET                       (always allowed, subject to allow/denylists)
- *   - write  → POST, PUT, PATCH          (requires --no-read-only)
- *   - delete → DELETE                    (requires --no-read-only AND --allow-deletes)
+ *   - write  → POST, PUT, PATCH          (blocked when --read-only is set)
+ *   - delete → DELETE                    (blocked when --read-only is set; also requires --allow-deletes)
  */
 
 export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";

--- a/src/helpers/sensitivePathDenylist.ts
+++ b/src/helpers/sensitivePathDenylist.ts
@@ -1,7 +1,7 @@
 /**
  * Hard denylist for `execute` paths that must never be reachable, regardless
  * of toolsets or mode flags. These are entries the user cannot opt into via
- * --no-read-only or --allow-deletes.
+ * --allow-deletes, and remain blocked even when --read-only is not set.
  *
  * Two categories live here:
  *   1. API-key management — creating or modifying API keys via the MCP server

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,12 +38,12 @@ program
     `Comma-separated list of toolsets to enable, or "all" (default: all). Available toolsets: ${DEFAULT_TOOLSETS.join(", ")}`,
   )
   .option(
-    "--no-read-only",
-    "Disable read-only mode to enable write operations (default: read-only enabled)",
+    "--read-only",
+    "Enable read-only mode: disable all write tools and block POST/PUT/PATCH/DELETE through the execute tool (default: write tools enabled)",
   )
   .option(
     "--allow-deletes",
-    "Permit DELETE-method requests through the execute tool. Requires --no-read-only. Default false.",
+    "Permit DELETE-method requests through the execute tool. Has no effect when --read-only is set. Default false.",
   )
   .option("--log-level <level>", "Minimum log level (info, error)", "info")
   .option(
@@ -78,7 +78,7 @@ const configuredServerUrl =
 const SERVER_INSTRUCTIONS = `
 The official Octopus Deploy MCP server, currently connected to: ${configuredServerUrl}
 
-Tools are grouped into toolsets (core, releases, deployments, tasks, tenants, kubernetes, machines, certificates, accounts, interruptions, featureToggles) and you can filter them via --toolsets. Writes are gated behind --no-read-only.
+Tools are grouped into toolsets (core, releases, deployments, tasks, tenants, kubernetes, machines, certificates, accounts, interruptions, featureToggles) and you can filter them via --toolsets. Writes are on by default; pass --read-only to gate them off.
 
 Resource URIs and how to dereference them:
 - Many tools return slim summaries plus an 'octopus://...' URI in fields like 'resourceUri' or 'taskResourceUri' instead of inlining heavy payloads (release notes, packaged versions, structured task activity trees, etc.). To fetch the full body, dereference the URI.
@@ -100,8 +100,8 @@ The same pattern applies to the API catalog: do NOT read 'octopus://api/llms.txt
 
 The 'execute' tool reaches Octopus REST endpoints not covered by curated tools. **Method gating is hard-coded server-side**, three tiers:
 - GET                    → read tier:   always allowed (subject to toolset allowlist + sensitive denylist).
-- POST / PUT / PATCH     → write tier:  requires --no-read-only AND user confirmation via elicitation.
-- DELETE                 → delete tier: requires --no-read-only AND --allow-deletes AND a stronger confirmation.
+- POST / PUT / PATCH     → write tier:  blocked when --read-only is set; requires user confirmation via elicitation otherwise.
+- DELETE                 → delete tier: requires --allow-deletes (and is blocked when --read-only is set) AND a stronger confirmation.
 
 The HTTP method enum IS the read/write/delete classifier — the runtime classifies based on the actual method, never on a flag the agent sets. Use grep_llms_txt to discover the right path + method before calling execute.
 
@@ -125,15 +125,14 @@ const toolsetConfig = createToolsetConfig(
   options.allowDeletes,
 );
 
-// `--allow-deletes` only takes effect when write mode is also enabled.
-// Surface this on stderr at startup so an operator who turned the flag on
-// without remembering --no-read-only doesn't silently end up with DELETE
-// requests still blocked by the read-only gate.
+// `--allow-deletes` only takes effect when writes are enabled. Surface this
+// on stderr at startup so an operator who set both --read-only and
+// --allow-deletes doesn't silently end up with DELETE requests blocked.
 if (toolsetConfig.allowDeletes && toolsetConfig.readOnlyMode) {
   process.stderr.write(
-    "WARNING: --allow-deletes was provided, but read-only mode is still " +
-      "enabled. DELETE requests through the execute tool remain blocked " +
-      "until --no-read-only is also set.\n",
+    "WARNING: --allow-deletes was provided, but --read-only is also set. " +
+      "DELETE requests through the execute tool remain blocked. Remove " +
+      "--read-only to enable DELETE.\n",
   );
 }
 

--- a/src/resources/catalog/__tests__/capabilities.test.ts
+++ b/src/resources/catalog/__tests__/capabilities.test.ts
@@ -212,7 +212,7 @@ describe("octopus://api/capabilities", () => {
     expect(listEntry.methodGated).toBeUndefined();
     expect(listEntry.tiersAvailable).toBeUndefined();
 
-    // --no-read-only without --allow-deletes: read + write reachable.
+    // writes enabled (no --read-only) without --allow-deletes: read + write reachable.
     setActiveToolsetConfig({ enabledToolsets: "all", readOnlyMode: false });
     cap = await buildCapabilities();
     executeEntry = cap.tools.find((t) => t.name === "execute")!;

--- a/src/resources/catalog/capabilities.ts
+++ b/src/resources/catalog/capabilities.ts
@@ -22,7 +22,7 @@ interface CapabilityToolEntry {
   methodGated?: boolean;
   /**
    * Effective method tiers reachable through this tool in the *current*
-   * session. For `execute` this reflects --no-read-only and --allow-deletes;
+   * session. For `execute` this reflects --read-only and --allow-deletes;
    * for static tools it is undefined (the `readOnly` flag is sufficient).
    */
   tiersAvailable?: MethodTier[];
@@ -57,7 +57,7 @@ export async function buildCapabilities(): Promise<Capabilities> {
 
   const activeConfig = getActiveToolsetConfig();
   const enabledToolsets = resolveEnabledToolsets();
-  const readOnlyMode = activeConfig.readOnlyMode ?? true;
+  const readOnlyMode = activeConfig.readOnlyMode ?? false;
   const allowDeletes = activeConfig.allowDeletes ?? false;
 
   const enabledSet = new Set<Toolset>(enabledToolsets);

--- a/src/tools/__tests__/execute.test.ts
+++ b/src/tools/__tests__/execute.test.ts
@@ -210,7 +210,7 @@ describe("execute tool — delete tier (DELETE)", () => {
     expect(body.message).toContain("--allow-deletes");
   });
 
-  it("blocks DELETE when --no-read-only is set but --allow-deletes is not", async () => {
+  it("blocks DELETE when --allow-deletes is not set", async () => {
     setActiveToolsetConfig({
       enabledToolsets: "all",
       readOnlyMode: false,

--- a/src/tools/execute.ts
+++ b/src/tools/execute.ts
@@ -136,7 +136,7 @@ const inputSchema = {
   method: z
     .enum(HTTP_METHODS as unknown as [HttpMethod, ...HttpMethod[]])
     .describe(
-      "HTTP method. The method itself is the read/write/delete classifier — GET is read-only, POST/PUT/PATCH require --no-read-only, DELETE additionally requires --allow-deletes. The agent cannot bypass this by lying about intent.",
+      "HTTP method. The method itself is the read/write/delete classifier — GET is read-only, POST/PUT/PATCH are blocked when --read-only is set, DELETE additionally requires --allow-deletes. The agent cannot bypass this by lying about intent.",
     ),
   path: z
     .string()
@@ -176,8 +176,8 @@ export function registerExecuteTool(server: McpServer) {
 **Method gating is hard-coded server-side, three tiers:**
 
   - GET    → read tier: always allowed (subject to toolset allowlist + sensitive denylist).
-  - POST/PUT/PATCH → write tier: requires --no-read-only AND user confirmation via elicitation.
-  - DELETE → delete tier: requires --no-read-only AND --allow-deletes AND a stronger user confirmation.
+  - POST/PUT/PATCH → write tier: blocked when --read-only is set; requires user confirmation via elicitation otherwise.
+  - DELETE → delete tier: requires --allow-deletes (and is blocked when --read-only is set) AND a stronger user confirmation.
 
 The HTTP method enum is the gate. The tool will not honour any 'isRead' flag the agent invents — the runtime classifies based on the actual method.
 
@@ -196,7 +196,7 @@ Discover endpoints with grep_llms_txt. Use octopus://api/capabilities to see whi
       const tier = classifyMethod(method);
       const audit = startAudit({ method, tier, path: rawPath });
       const config = getActiveToolsetConfig();
-      const readOnlyMode = config.readOnlyMode ?? true;
+      const readOnlyMode = config.readOnlyMode ?? false;
       const allowDeletes = config.allowDeletes ?? false;
 
       // Gate 0: path canonicalization. Reject paths that can mean different
@@ -232,7 +232,7 @@ Discover endpoints with grep_llms_txt. Use octopus://api/capabilities to see whi
           success: false,
           reason: "readOnlyMode",
           message:
-            "This server is in read-only mode. Restart with --no-read-only to enable write requests through the execute tool.",
+            "This server is in read-only mode. Restart without --read-only to enable write requests through the execute tool.",
         });
       }
       if (tier === "delete") {
@@ -242,7 +242,7 @@ Discover endpoints with grep_llms_txt. Use octopus://api/capabilities to see whi
             success: false,
             reason: "readOnlyMode",
             message:
-              "This server is in read-only mode. Restart with --no-read-only AND --allow-deletes to permit DELETE requests through the execute tool.",
+              "This server is in read-only mode. Restart without --read-only AND with --allow-deletes to permit DELETE requests through the execute tool.",
           });
         }
         if (!allowDeletes) {
@@ -251,7 +251,7 @@ Discover endpoints with grep_llms_txt. Use octopus://api/capabilities to see whi
             success: false,
             reason: "deletesNotAllowed",
             message:
-              "DELETE requests are not permitted. Restart with --allow-deletes (in addition to --no-read-only) to enable them. This is a deliberate two-flag opt-in for irreversible operations.",
+              "DELETE requests are not permitted. Restart with --allow-deletes to enable them. This is a deliberate opt-in for irreversible operations.",
           });
         }
       }

--- a/src/types/toolConfig.ts
+++ b/src/types/toolConfig.ts
@@ -27,7 +27,7 @@ export interface ToolsetConfig {
   /**
    * Permit DELETE-method requests through the `execute` backstop tool.
    * Requires `readOnlyMode: false` to take effect — the read-only gate runs
-   * first. Default false (no DELETE allowed even with --no-read-only).
+   * first. Default false (no DELETE allowed unless explicitly opted in).
    */
   allowDeletes?: boolean;
 }

--- a/src/utils/parseConfig.ts
+++ b/src/utils/parseConfig.ts
@@ -25,7 +25,7 @@ export function createToolsetConfig(
 ): ToolsetConfig {
   return {
     enabledToolsets: parseToolsets(toolsetsArg),
-    readOnlyMode: readOnlyArg ?? true, // Default to read-only mode
+    readOnlyMode: readOnlyArg ?? false, // Default: writes enabled. Pass --read-only to gate them.
     allowDeletes: allowDeletesArg ?? false, // Default deny all DELETEs
   };
 }


### PR DESCRIPTION
## Summary

Removes `--no-read-only` and replaces it with `--read-only`, flipping the default so write tools are enabled out of the box. Pass `--read-only` to disable all curated write tools and block POST/PUT/PATCH/DELETE through the `execute` backstop.

The internal `readOnlyMode` boolean keeps its meaning (`true` = hide writes) — only the CLI flag name, the default value, and user-facing strings change. The `octopus://api/capabilities` JSON shape (`session.readOnlyMode`) is unchanged.

## Breaking change

`--no-read-only` is removed cleanly (no deprecation alias). Passing it produces a Commander `unknown option` error at startup.

- Users who relied on `--no-read-only` to enable writes should drop the flag.
- Users who want the previous default (read-only) should now pass `--read-only`.

`--allow-deletes` is unchanged in mechanism. Its docs and the combined-flag startup warning have been rewritten — it now reads as "has no effect when `--read-only` is set."

## Changes

- **CLI** ([src/index.ts](src/index.ts)): replaced the `--no-read-only` option with `--read-only`; updated `--allow-deletes` description, the SERVER_INSTRUCTIONS string, and the combined-flag stderr warning.
- **Default** ([src/utils/parseConfig.ts](src/utils/parseConfig.ts)): `readOnlyArg ?? true` → `readOnlyArg ?? false`.
- **Fallback defaults**: matched the new default in [capabilities.ts:60](src/resources/catalog/capabilities.ts) and [execute.ts:199](src/tools/execute.ts) (both flipped to `?? false`).
- **Error messages and tool description** in [src/tools/execute.ts](src/tools/execute.ts): all four user-visible strings (HTTP method field, top-level description, `readOnlyMode` write/delete branches, `deletesNotAllowed` branch).
- **Doc comments** in `methodTier.ts`, `toolConfig.ts`, `sensitivePathDenylist.ts`, `capabilities.ts`.
- **Tests**: renamed the DELETE-without-allow-deletes test; updated one stale comment in `capabilities.test.ts`. Test bodies were unchanged because they exercise the internal `readOnlyMode` boolean directly.
- **README**: swapped the two config examples (writes-default first, `--read-only` second), rewrote the `#### Read-Only Mode` section, the three-tier explanation, bash examples, command-line-arguments bullets, and the Security Considerations section.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npx vitest run src/tools/__tests__/execute.test.ts src/resources/catalog/__tests__/capabilities.test.ts` — 22/22 pass
- [ ] Smoke test default (no flag): confirm `create_release`, `deploy_release`, `run_runbook`, `update_feature_toggle` are registered and `execute` with `method: "POST"` reaches the elicitation prompt rather than the `readOnlyMode` block
- [ ] Smoke test `--read-only`: confirm those tools are absent and `execute` with `method: "POST"` returns the new "Restart without --read-only" error
- [ ] Smoke test `--read-only --allow-deletes`: confirm the new stderr WARNING text fires
- [ ] Smoke test `--no-read-only`: confirm Commander prints `error: unknown option '--no-read-only'` and exits non-zero
- [ ] Fetch `octopus://api/capabilities` in both modes and confirm `session.readOnlyMode` and `execute.tiersAvailable` reflect the active flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)