### PR TITLE
chore: address PR #83 review feedback on read-only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,11 @@ The server uses a three-tier read/write/delete classification, enforced server-s
 # Default - write tools enabled (POST/PUT/PATCH)
 npx -y @octopusdeploy/mcp-server
 
-# Read-only mode - write/delete tools disabled
-npx -y @octopusdeploy/mcp-server --read-only
-
 # Additionally permit DELETE requests through the execute tool
 npx -y @octopusdeploy/mcp-server --allow-deletes
+
+# Read-only mode - write/delete tools disabled
+npx -y @octopusdeploy/mcp-server --read-only
 ```
 
 **Security Note:** Use an API key with appropriate, least-privilege permissions — write operations can create releases and trigger deployments in your Octopus instance. For production, consider passing `--read-only` unless you have a specific, controlled use case for writes. `--allow-deletes` is off by default; only enable it when the agent must issue DELETE requests through `execute`. If you pass `--allow-deletes` together with `--read-only`, the server prints a startup warning to stderr — DELETE requests remain blocked by the read-only gate.
@@ -250,7 +250,7 @@ npx -y @octopusdeploy/mcp-server --server-url https://your-octopus.com
 #### Other command line arguments
 
 * `--read-only` - Enable read-only mode: disable all curated write tools and block POST/PUT/PATCH/DELETE through `execute`. Writes are enabled by default; this flag turns them off. See [Read-Only Mode](#read-only-mode).
-* `--allow-deletes` - Permit DELETE requests through the `execute` tool. Has no effect when `--read-only` is set. Default `false`.
+* `--allow-deletes` - Permit DELETE requests through the `execute` tool. Ignored (with a startup warning) when `--read-only` is set. Default `false`.
 * `--log-level <level>` - Minimum log level (info, error)
 * `--log-file <path>` - Log file path or filename. If not specified, logs are written to console only
 * `-q, --quiet` - Disable file logging, only log errors to console

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ program
   )
   .option(
     "--allow-deletes",
-    "Permit DELETE-method requests through the execute tool. Has no effect when --read-only is set. Default false.",
+    "Permit DELETE-method requests through the execute tool. Ignored (with a startup warning) when --read-only is set. Default false.",
   )
   .option("--log-level <level>", "Minimum log level (info, error)", "info")
   .option(
@@ -78,7 +78,7 @@ const configuredServerUrl =
 const SERVER_INSTRUCTIONS = `
 The official Octopus Deploy MCP server, currently connected to: ${configuredServerUrl}
 
-Tools are grouped into toolsets (core, releases, deployments, tasks, tenants, kubernetes, machines, certificates, accounts, interruptions, featureToggles) and you can filter them via --toolsets. Writes are on by default; pass --read-only to gate them off.
+Tools are grouped into toolsets (${DEFAULT_TOOLSETS.join(", ")}) and you can filter them via --toolsets. Writes are on by default; pass --read-only to gate them off.
 
 Resource URIs and how to dereference them:
 - Many tools return slim summaries plus an 'octopus://...' URI in fields like 'resourceUri' or 'taskResourceUri' instead of inlining heavy payloads (release notes, packaged versions, structured task activity trees, etc.). To fetch the full body, dereference the URI.

--- a/src/utils/__tests__/parseConfig.test.ts
+++ b/src/utils/__tests__/parseConfig.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { createToolsetConfig, parseToolsets } from "../parseConfig.js";
+
+describe("createToolsetConfig", () => {
+  it("defaults readOnlyMode to false (writes enabled) when --read-only is not set", () => {
+    const config = createToolsetConfig(undefined, undefined, undefined);
+    expect(config.readOnlyMode).toBe(false);
+  });
+
+  it("sets readOnlyMode to true when --read-only is passed", () => {
+    const config = createToolsetConfig(undefined, true, undefined);
+    expect(config.readOnlyMode).toBe(true);
+  });
+
+  it("defaults allowDeletes to false", () => {
+    const config = createToolsetConfig(undefined, undefined, undefined);
+    expect(config.allowDeletes).toBe(false);
+  });
+
+  it("passes allowDeletes through when set", () => {
+    const config = createToolsetConfig(undefined, undefined, true);
+    expect(config.allowDeletes).toBe(true);
+  });
+
+  it("defaults enabledToolsets to 'all' when no --toolsets arg is given", () => {
+    const config = createToolsetConfig(undefined, undefined, undefined);
+    expect(config.enabledToolsets).toBe("all");
+  });
+});
+
+describe("parseToolsets", () => {
+  it("returns 'all' when arg is undefined", () => {
+    expect(parseToolsets(undefined)).toBe("all");
+  });
+
+  it("returns 'all' when arg is the literal 'all'", () => {
+    expect(parseToolsets("all")).toBe("all");
+  });
+
+  it("splits a comma-separated list and trims whitespace", () => {
+    expect(parseToolsets("core, projects ,deployments")).toEqual([
+      "core",
+      "projects",
+      "deployments",
+    ]);
+  });
+
+  it("throws for an unknown toolset name", () => {
+    expect(() => parseToolsets("core,bogus")).toThrow(/Invalid toolsets: bogus/);
+  });
+});


### PR DESCRIPTION
Follow-up to [#83](https://github.com/OctopusDeploy/mcp-server/pull/83). Addresses four review items.

## Summary

- **Pin the new default with a unit test.** Added `src/utils/__tests__/parseConfig.test.ts` so `createToolsetConfig(undefined, undefined, undefined).readOnlyMode === false` is asserted. The existing `execute.test.ts` and `capabilities.test.ts` set `readOnlyMode` on `ToolsetConfig` directly, so they cover the gate but not the CLI-to-boolean translation that actually changed in #83. A stray `?? true` regression in [src/utils/parseConfig.ts:28](https://github.com/OctopusDeploy/mcp-server/blob/main/src/utils/parseConfig.ts#L28) is now caught.
- **Match `--allow-deletes` help text to the runtime.** The previous text said "Has no effect when `--read-only` is set," but the runtime writes a stderr WARNING when both are set ([src/index.ts:131-137](https://github.com/OctopusDeploy/mcp-server/blob/main/src/index.ts#L131-L137)). Reworded to "Ignored (with a startup warning) when `--read-only` is set" in both [src/index.ts:46](https://github.com/OctopusDeploy/mcp-server/blob/main/src/index.ts#L46) and the README's command-line-arguments bullet.
- **Stop hand-rolling the toolset list in SERVER_INSTRUCTIONS.** The hand-rolled list at [src/index.ts:81](https://github.com/OctopusDeploy/mcp-server/blob/main/src/index.ts#L81) was missing `projects`, `runbooks`, and `context` compared to `DEFAULT_TOOLSETS` in [src/types/toolConfig.ts:48](https://github.com/OctopusDeploy/mcp-server/blob/main/src/types/toolConfig.ts#L48). Replaced with `${DEFAULT_TOOLSETS.join(", ")}` so it cannot drift again — same pattern the `--toolsets` option description two lines up already uses. Pre-dates #83 but the line was touched there, so worth fixing here.
- **Reorder the README example block.** The three examples ran default → `--read-only` → `--allow-deletes`. The third comment ("Additionally permit DELETE requests") sat right after the `--read-only` block, which read as "add `--allow-deletes` on top of `--read-only`" — precisely the no-op combination the startup warning calls out. Reordered to default → `--allow-deletes` → `--read-only` so the `--allow-deletes` comment now visibly adds to the writes-enabled default.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npx vitest run src/utils/__tests__/parseConfig.test.ts` — 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)