### PR TITLE
fix: make execute tool honestly report readOnly:false in capabilities

### DIFF
--- a/src/resources/catalog/__tests__/capabilities.test.ts
+++ b/src/resources/catalog/__tests__/capabilities.test.ts
@@ -31,10 +31,11 @@ function fakeRegistration(
   toolset: ToolRegistration["config"]["toolset"],
   readOnly: boolean,
   minimumOctopusVersion?: string,
+  methodGated?: boolean,
 ): ToolRegistration {
   return {
     toolName,
-    config: { toolset, readOnly },
+    config: { toolset, readOnly, methodGated },
     registerFn: () => {},
     minimumOctopusVersion,
   };
@@ -193,18 +194,21 @@ describe("octopus://api/capabilities", () => {
 
     TOOL_REGISTRY.set(
       "execute",
-      fakeRegistration("execute", "core", true),
+      fakeRegistration("execute", "core", false, undefined, true),
     );
     TOOL_REGISTRY.set(
       "list_spaces",
       fakeRegistration("list_spaces", "core", true),
     );
 
-    // Read-only mode: only the read tier is reachable.
+    // Read-only mode: execute is still listed (methodGated bypass) but only
+    // the read tier is reachable, and it honestly reports readOnly:false so
+    // clients don't auto-classify it as a reader.
     setActiveToolsetConfig({ enabledToolsets: "all", readOnlyMode: true });
     let cap = await buildCapabilities();
     let executeEntry = cap.tools.find((t) => t.name === "execute")!;
     expect(executeEntry.methodGated).toBe(true);
+    expect(executeEntry.readOnly).toBe(false);
     expect(executeEntry.tiersAvailable).toEqual(["read"]);
 
     // Static read-only tools must NOT carry methodGated/tiersAvailable.

--- a/src/resources/catalog/capabilities.ts
+++ b/src/resources/catalog/capabilities.ts
@@ -8,6 +8,7 @@ import {
 } from "../../types/toolConfig.js";
 import { getActiveToolsetConfig } from "../../helpers/activeToolsetConfig.js";
 import { type MethodTier } from "../../helpers/methodTier.js";
+import { isToolEnabled } from "../../tools/index.js";
 
 interface CapabilityToolEntry {
   name: string;
@@ -65,15 +66,11 @@ export async function buildCapabilities(): Promise<Capabilities> {
 
   const tools: CapabilityToolEntry[] = [];
   for (const [name, registration] of TOOL_REGISTRY) {
-    if (!enabledSet.has(registration.config.toolset)) continue;
-    // Method-gated tools (e.g. `execute`) stay listed in read-only mode —
-    // they decide their own tier at runtime. Static write tools drop out.
-    if (
-      readOnlyMode &&
-      !registration.config.readOnly &&
-      !registration.config.methodGated
-    )
-      continue;
+    // Single source of truth: the catalog lists exactly the tools that
+    // `registerTools` would register for this session. Any future filter
+    // rule (new tier flag, dynamic toolset gate, etc.) reaches the catalog
+    // automatically — which is the class of bug this file just fixed.
+    if (!isToolEnabled(registration, activeConfig)) continue;
     const entry: CapabilityToolEntry = {
       name,
       toolset: registration.config.toolset,

--- a/src/resources/catalog/capabilities.ts
+++ b/src/resources/catalog/capabilities.ts
@@ -66,18 +66,21 @@ export async function buildCapabilities(): Promise<Capabilities> {
   const tools: CapabilityToolEntry[] = [];
   for (const [name, registration] of TOOL_REGISTRY) {
     if (!enabledSet.has(registration.config.toolset)) continue;
-    if (readOnlyMode && !registration.config.readOnly) continue;
+    // Method-gated tools (e.g. `execute`) stay listed in read-only mode —
+    // they decide their own tier at runtime. Static write tools drop out.
+    if (
+      readOnlyMode &&
+      !registration.config.readOnly &&
+      !registration.config.methodGated
+    )
+      continue;
     const entry: CapabilityToolEntry = {
       name,
       toolset: registration.config.toolset,
       readOnly: registration.config.readOnly,
       minimumOctopusVersion: registration.minimumOctopusVersion,
     };
-    // The execute tool registers as readOnly:true (so it survives the
-    // registration filter in read-only mode for its GET branch) but its
-    // actual behaviour is method-gated. Surface that explicitly so callers
-    // don't conclude execute is fully read-only.
-    if (name === "execute") {
+    if (registration.config.methodGated) {
       entry.methodGated = true;
       const tiers: MethodTier[] = ["read"];
       if (!readOnlyMode) tiers.push("write");

--- a/src/tools/__tests__/registrationFilter.test.ts
+++ b/src/tools/__tests__/registrationFilter.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { isToolEnabled } from "../index.js";
+import { type ToolRegistration } from "../../types/toolConfig.js";
+
+function fakeRegistration(
+  toolName: string,
+  toolset: ToolRegistration["config"]["toolset"],
+  readOnly: boolean,
+  methodGated?: boolean,
+): ToolRegistration {
+  return {
+    toolName,
+    config: { toolset, readOnly, methodGated },
+    registerFn: () => {},
+  };
+}
+
+describe("isToolEnabled — read-only mode and methodGated bypass", () => {
+  it("registers static read-only tools in read-only mode", () => {
+    const reg = fakeRegistration("list_spaces", "core", true);
+    expect(isToolEnabled(reg, { readOnlyMode: true })).toBe(true);
+  });
+
+  it("hides static write tools in read-only mode", () => {
+    const reg = fakeRegistration("create_release", "releases", false);
+    expect(
+      isToolEnabled(reg, { enabledToolsets: "all", readOnlyMode: true }),
+    ).toBe(false);
+  });
+
+  it("keeps methodGated tools registered in read-only mode even though they're not statically read-only", () => {
+    const reg = fakeRegistration("execute", "core", false, true);
+    expect(isToolEnabled(reg, { readOnlyMode: true })).toBe(true);
+  });
+
+  it("registers write tools when read-only mode is off", () => {
+    const reg = fakeRegistration("create_release", "releases", false);
+    expect(
+      isToolEnabled(reg, { enabledToolsets: "all", readOnlyMode: false }),
+    ).toBe(true);
+  });
+
+  it("hides tools whose toolset is not enabled, regardless of readOnly", () => {
+    const reg = fakeRegistration("find_certificates", "certificates", true);
+    expect(
+      isToolEnabled(reg, {
+        enabledToolsets: ["releases"],
+        readOnlyMode: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("always registers core-toolset tools regardless of enabledToolsets", () => {
+    const reg = fakeRegistration("list_spaces", "core", true);
+    expect(
+      isToolEnabled(reg, {
+        enabledToolsets: ["releases"],
+        readOnlyMode: false,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/tools/execute.ts
+++ b/src/tools/execute.ts
@@ -349,9 +349,10 @@ Discover endpoints with grep_llms_txt. Use octopus://api/capabilities to see whi
 
 registerToolDefinition({
   toolName: "execute",
-  // readOnly: true so the tool is registered even in --read-only mode (where
-  // only its GET branch is reachable). Method-tier gating inside the handler
-  // enforces the actual write/delete policy at runtime.
-  config: { toolset: "core", readOnly: true },
+  // execute is not statically read-only — its tier depends on the HTTP method
+  // passed in. methodGated: true keeps it registered even in --read-only mode
+  // (where only its GET branch is reachable), and the catalog surfaces the
+  // honest `readOnly: false` so clients don't auto-classify it as a reader.
+  config: { toolset: "core", readOnly: false, methodGated: true },
   registerFn: registerExecuteTool,
 });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -50,7 +50,7 @@ import "./execute.js";
 
 // Resource backstop for clients without native MCP resource support
 import "./readResource.js";
-function isToolEnabled(
+export function isToolEnabled(
   toolRegistration: ToolRegistration,
   config: ToolsetConfig,
 ): boolean {
@@ -71,8 +71,14 @@ function isToolEnabled(
     return false;
   }
 
-  // Check read-only mode
-  if (config.readOnlyMode && !toolRegistration.config.readOnly) {
+  // Check read-only mode. Method-gated tools (e.g. `execute`) bypass this
+  // filter because they classify themselves at runtime — they stay registered
+  // even in read-only mode, where the handler will refuse non-read calls.
+  if (
+    config.readOnlyMode &&
+    !toolRegistration.config.readOnly &&
+    !toolRegistration.config.methodGated
+  ) {
     return false;
   }
 

--- a/src/types/toolConfig.ts
+++ b/src/types/toolConfig.ts
@@ -19,6 +19,14 @@ export type Toolset =
 export interface ToolConfig {
   toolset: Toolset;
   readOnly: boolean;
+  /**
+   * Tools whose actual read/write/delete tier is determined at runtime by
+   * tool arguments (typically the HTTP method passed in) rather than the
+   * static `readOnly` flag. Setting this to `true` bypasses the read-only
+   * registration filter — the tool must do its own tier gating in the
+   * handler. Currently set only on `execute`.
+   */
+  methodGated?: boolean;
 }
 
 export interface ToolsetConfig {


### PR DESCRIPTION
## Problem

The `execute` tool was registered with `config.readOnly: true` purely to bypass the read-only registration filter, then handled method-tier gating internally. The `octopus://api/capabilities` resource faithfully surfaced that flag, so it reported `execute.readOnly: true` **even though** `tiersAvailable` showed `["read", "write"]` or `["read", "write", "delete"]`.

This is a real bug, not just a cosmetic issue: any client that auto-classifies tools by the `readOnly` field — a downstream auto-mode classifier, a future MCP UI, an agent's own caution heuristic — denied write requests that the server would have allowed. The catalog and the runtime were saying contradictory things about the same tool.

Reported on PR #85.

## Fix

Stop lying. Make `execute` register honestly and add a first-class mechanism for "method-gated" tools.

- **New `ToolConfig.methodGated` field** in [src/types/toolConfig.ts](src/types/toolConfig.ts). Tools that set it classify themselves at runtime and bypass the read-only registration filter.
- **Registration filter** in [src/tools/index.ts:74-83](src/tools/index.ts) now lets `methodGated: true` through even when `readOnlyMode: true` and `readOnly: false`. Static write tools (`create_release`, `deploy_release`, etc.) still drop out in read-only mode.
- **`execute` registration** in [src/tools/execute.ts:350-357](src/tools/execute.ts) is now `{ toolset: "core", readOnly: false, methodGated: true }`. The comment that justified the previous lie is gone.
- **Capabilities builder** in [src/resources/catalog/capabilities.ts](src/resources/catalog/capabilities.ts) now derives `methodGated` and `tiersAvailable` from `registration.config.methodGated` instead of a name-match on `"execute"`. The catalog's `readOnly` field now reflects reality.
- **`isToolEnabled` is now exported** so it's testable.
- **New test file**: [src/tools/__tests__/registrationFilter.test.ts](src/tools/__tests__/registrationFilter.test.ts) — 6 tests covering the read-only + methodGated bypass matrix.
- **Capabilities test updated**: `fakeRegistration` helper now accepts `methodGated`; the execute test asserts `executeEntry.readOnly === false` in read-only mode.

## What clients see now

In a default session (writes enabled):
```jsonc
{
  "name": "execute",
  "readOnly": false,          // honest
  "methodGated": true,
  "tiersAvailable": ["read", "write"]
}
```

In a `--read-only` session, `execute` is still listed (so its GET branch remains reachable), but:
```jsonc
{
  "name": "execute",
  "readOnly": false,          // still honest — execute isn't statically read-only
  "methodGated": true,
  "tiersAvailable": ["read"]  // only read is reachable here
}
```

A client that auto-classifies by `readOnly` will now correctly treat `execute` as "could write." A client that wants the full picture reads `methodGated` + `tiersAvailable`.

## Out of scope

Reporter noted there are no curated writers for feeds or deployment processes. That's a separate feature ask, not a bug in this gate — `execute` + `--allow-deletes`-free POST/PUT/PATCH is the current path for those, and this fix is what makes those calls reach the runtime gate instead of getting auto-denied by the catalog.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npx vitest run src/tools/__tests__/registrationFilter.test.ts src/resources/catalog/__tests__/capabilities.test.ts src/tools/__tests__/execute.test.ts` — 28/28 pass
- [ ] Smoke test: start a default-mode server, fetch `octopus://api/capabilities`, confirm `tools[].readOnly === false` for `execute` and `tiersAvailable === ["read", "write"]`
- [ ] Smoke test: start with `--read-only`, confirm `execute` is still in the tool list with `readOnly: false`, `methodGated: true`, and `tiersAvailable: ["read"]`
- [ ] Smoke test: POST through `execute` in a default session and confirm the elicitation prompt fires (not a catalog-driven auto-deny)

🤖 Generated with [Claude Code](https://claude.com/claude-code)