### PR TITLE
feat: improve tool response ergonomics

### DIFF
--- a/src/helpers/__tests__/grepLines.test.ts
+++ b/src/helpers/__tests__/grepLines.test.ts
@@ -166,4 +166,97 @@ describe("grepLines", () => {
     expect(result.totalMatches).toBe(0);
     expect(result.matches).toEqual([]);
   });
+
+  describe("stripPrefixes", () => {
+    it("strips ISO timestamp + level prefix from returned lines", () => {
+      const result = grepLines(SAMPLE_LOG, {
+        ...baseParams,
+        pattern: "Connection timeout",
+        stripPrefixes: true,
+      });
+
+      expect(result.totalMatches).toBe(1);
+      expect(result.matches[0].line).toBe("Connection timeout to database");
+    });
+
+    it("strips HH:MM:SS-only prefix (real Octopus output shape)", () => {
+      const log = [
+        "04:36:40   Fatal    | The deployment failed",
+        "04:36:41   Info     | Cleaning up",
+        "",
+      ].join("\n");
+
+      const result = grepLines(log, {
+        ...baseParams,
+        pattern: "failed",
+        stripPrefixes: true,
+      });
+
+      expect(result.totalMatches).toBe(1);
+      expect(result.matches[0].line).toBe("The deployment failed");
+    });
+
+    it("strips prefix before pattern matching so level names don't produce false matches", () => {
+      // Without stripping, `Info` matches every Info-level line (5).
+      const withoutStrip = grepLines(SAMPLE_LOG, {
+        ...baseParams,
+        pattern: "Info",
+      });
+      expect(withoutStrip.totalMatches).toBe(5);
+
+      // With stripping, `Info` no longer appears in the prefix, so it only
+      // matches lines whose message body literally contains "Info" (none here).
+      const withStrip = grepLines(SAMPLE_LOG, {
+        ...baseParams,
+        pattern: "Info",
+        stripPrefixes: true,
+      });
+      expect(withStrip.totalMatches).toBe(0);
+    });
+
+    it("leaves lines without a recognizable prefix untouched", () => {
+      const log = [
+        "2026-05-05T12:00:00 Info  | Step starting",
+        "        continuation line with leading whitespace",
+        "bare line with no prefix at all",
+        "",
+      ].join("\n");
+
+      const result = grepLines(log, {
+        ...baseParams,
+        pattern: ".",
+        stripPrefixes: true,
+      });
+
+      expect(result.matches.map((m) => m.line)).toEqual([
+        "Step starting",
+        "        continuation line with leading whitespace",
+        "bare line with no prefix at all",
+      ]);
+    });
+
+    it("strips prefixes from context lines too", () => {
+      const result = grepLines(SAMPLE_LOG, {
+        ...baseParams,
+        pattern: "Connection timeout",
+        beforeContext: 1,
+        afterContext: 1,
+        stripPrefixes: true,
+      });
+
+      expect(result.matches[0].before?.[0].line).toBe("Step 2 starting");
+      expect(result.matches[0].after?.[0].line).toBe("Step 2 failed: see above");
+    });
+
+    it("defaults to false (existing behavior is preserved)", () => {
+      const result = grepLines(SAMPLE_LOG, {
+        ...baseParams,
+        pattern: "Connection timeout",
+      });
+
+      expect(result.matches[0].line).toBe(
+        "2026-05-05T12:00:05 Error | Connection timeout to database",
+      );
+    });
+  });
 });

--- a/src/helpers/grepLines.ts
+++ b/src/helpers/grepLines.ts
@@ -17,6 +17,7 @@ export interface GrepLinesParams {
   beforeContext?: number;
   afterContext?: number;
   maxCount?: number;
+  stripPrefixes?: boolean;
 }
 
 export interface ContextLine {
@@ -39,6 +40,14 @@ export interface GrepLinesResult {
 
 export const MAX_CONTEXT = 50;
 export const MAX_COUNT_HARD_CAP = 500;
+
+// Octopus task-log line prefix: an optional ISO date, a HH:MM:SS time, one or
+// more spaces, a level token (Info/Warn/Error/Fatal/Verbose/etc.), one or more
+// spaces, a pipe, and an optional space. Examples:
+//   "04:36:40   Fatal    | message"          (real server output)
+//   "2026-05-05T12:00:00 Info  | message"    (test fixtures)
+// Lines that don't match the shape are left untouched.
+const LOG_PREFIX_REGEX = /^(?:\d{4}-\d{2}-\d{2}T)?\d{2}:\d{2}:\d{2}\s+\S+\s+\|\s?/;
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -73,11 +82,20 @@ export function grepLines(
     beforeContext = 0,
     afterContext = 0,
     maxCount = 100,
+    stripPrefixes = false,
   } = params;
 
-  const lines = rawText.split("\n");
+  const rawLines = rawText.split("\n");
   // Drop the trailing empty element produced by a final newline.
-  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  if (rawLines.length > 0 && rawLines[rawLines.length - 1] === "") rawLines.pop();
+
+  // When stripPrefixes is on, the timestamp/level prefix is removed before
+  // pattern matching AND before output, so the caller's regex doesn't see the
+  // prefix (no false matches against level names) and the returned line/context
+  // text is clean for downstream consumption.
+  const lines = stripPrefixes
+    ? rawLines.map((line) => line.replace(LOG_PREFIX_REGEX, ""))
+    : rawLines;
 
   const regex = compilePattern(pattern, caseInsensitive, fixedString);
 

--- a/src/resources/task.ts
+++ b/src/resources/task.ts
@@ -17,7 +17,7 @@ registerResourceDescriptor({
   toolset: "tasks",
   title: "Octopus task summary",
   description:
-    "Lightweight task metadata: state, timing, completion flags, and arguments. Cheap to fetch — use this for polling or status checks. For step timings and embedded log entries use the /details URI; to search the raw activity log call the grep_task_log tool.",
+    "Lightweight task metadata: state, timing, completion flags, and arguments. Cheap to fetch — use this for polling or status checks. For the full ActivityLogs tree and step timings use the /details URI (same body returned by get_task_from_url when starting from a portal URL); to search the raw activity log call the grep_task_log tool.",
   mimeType: "application/json",
   read: async ({ spaceName, taskId }) => {
     validateEntityId(taskId, "task", ENTITY_PREFIXES.task);
@@ -51,7 +51,7 @@ registerResourceDescriptor({
   toolset: "tasks",
   title: "Octopus task details (structured activity tree)",
   description:
-    "Full ServerTaskDetails payload: the task summary plus Progress, PhysicalLogSize, and the hierarchical ActivityLogs tree (each step's children, status, and embedded log entries). Heavier than the /task summary — fetch when you need step-by-step timings or programmatic access to log entries.",
+    "Full ServerTaskDetails payload: the task summary plus Progress, PhysicalLogSize, and the hierarchical ActivityLogs tree (each step's children, status, and embedded log entries). Heavier than the /task summary — fetch when you need step-by-step timings or programmatic access to log entries. `get_task_from_url` returns this same body when starting from a portal URL; don't double-fetch.",
   mimeType: "application/json",
   read: async ({ spaceName, taskId }) => {
     validateEntityId(taskId, "task", ENTITY_PREFIXES.task);

--- a/src/tools/createRelease.ts
+++ b/src/tools/createRelease.ts
@@ -1,4 +1,8 @@
-import { Client, ReleaseRepository } from "@octopusdeploy/api-client";
+import {
+  Client,
+  ReleaseRepository,
+  type SelectedPackage,
+} from "@octopusdeploy/api-client";
 import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
@@ -138,12 +142,23 @@ This tool creates a new release for a project. The space name and project name a
 
         const response = await releaseRepository.create(command);
 
-        let versionControlReference: { GitRef?: string; GitCommit?: string } | undefined;
+        // Fetch the persisted Release so we can echo VersionControlReference and
+        // the resolved SelectedPackages. The create response only carries the
+        // ReleaseId/ReleaseVersion; SelectedPackages comes from the resolved
+        // release body and is the single most useful field for the caller to
+        // confirm version-template / channel-rule resolution without a second
+        // round trip.
+        let versionControlReference:
+          | { GitRef?: string; GitCommit?: string }
+          | undefined;
+        let selectedPackages: SelectedPackage[] | undefined;
         try {
           const release = await releaseRepository.get(response.ReleaseId);
           versionControlReference = release.VersionControlReference;
+          selectedPackages = release.SelectedPackages;
         } catch {
           versionControlReference = undefined;
+          selectedPackages = undefined;
         }
 
         const encodedSpace = encodeURIComponent(spaceName);
@@ -160,10 +175,11 @@ This tool creates a new release for a project. The space name and project name a
                   releaseId: response.ReleaseId,
                   releaseVersion: response.ReleaseVersion,
                   versionControlReference,
+                  selectedPackages,
                   resourceUri,
                   message: `Release ${response.ReleaseVersion} created successfully`,
                   helpText:
-                    "Read resourceUri for the full release body (includes releaseNotes). Use deploy_release to deploy this release to environments.",
+                    "selectedPackages shows the resolved package versions bound to this release. Read resourceUri for the full release body (includes releaseNotes). Use deploy_release to deploy this release to environments.",
                 },
                 null,
                 2,

--- a/src/tools/deployRelease.ts
+++ b/src/tools/deployRelease.ts
@@ -224,6 +224,7 @@ The tool automatically determines which deployment type to use based on the para
 
         // Format the response
         const tasks = response.DeploymentServerTasks || [];
+        const encodedSpace = encodeURIComponent(spaceName);
 
         return {
           content: [
@@ -237,9 +238,10 @@ The tool automatically determines which deployment type to use based on the para
                   deploymentTasks: tasks.map((task) => ({
                     taskId: task.ServerTaskId,
                     deploymentId: task.DeploymentId,
+                    taskResourceUri: `octopus://spaces/${encodedSpace}/tasks/${encodeURIComponent(task.ServerTaskId)}/details`,
                   })),
                   message: `Successfully created ${tasks.length} deployment(s) for release ${releaseVersion}`,
-                  helpText: `Fetch octopus://spaces/{spaceName}/tasks/{taskId} (or /details for the structured activity tree) via resources/read or read_resource to monitor deployment progress. To search the raw log for a specific error or step, call grep_task_log with the taskId. Use list_deployments for high-level deployment listings.`,
+                  helpText: `Feed each deploymentTasks[].taskResourceUri into read_resource (or resources/read) to monitor deployment progress via the structured ActivityLogs tree. For the lighter metadata-only view, swap /details off the URI. To search the raw log for a specific error or step, call grep_task_log with the taskId. Use list_deployments for high-level deployment listings.`,
                 },
                 null,
                 2,

--- a/src/tools/getTaskFromUrl.ts
+++ b/src/tools/getTaskFromUrl.ts
@@ -64,6 +64,8 @@ export function registerGetTaskFromUrlTool(server: McpServer) {
       title: 'Get task details from an Octopus Deploy URL',
       description: `Get task details from an Octopus Deploy task URL. Returns full task details including execution logs and state.
 
+This tool is a URL-to-ID resolver that returns the **same body** as the \`octopus://spaces/{spaceName}/tasks/{taskId}/details\` resource — no need to dereference the URI afterward. If you only need lightweight metadata for polling (state, timing, completion flags) use the smaller \`octopus://spaces/{spaceName}/tasks/{taskId}\` resource instead.
+
 Accepts task URLs like:
 https://your-octopus.com/app#/Spaces-1/tasks/ServerTasks-456
 

--- a/src/tools/grepTaskLog.ts
+++ b/src/tools/grepTaskLog.ts
@@ -26,6 +26,7 @@ export interface GrepTaskLogParams {
   beforeContext?: number;
   afterContext?: number;
   maxCount?: number;
+  stripPrefixes?: boolean;
 }
 
 export interface GrepTaskLogResult {
@@ -90,6 +91,12 @@ const inputSchema = {
     .max(MAX_COUNT_HARD_CAP)
     .default(100)
     .describe(`Equivalent to grep -m: stop returning matches after this many. totalMatches in the response still reflects the true count across the whole log. Hard cap ${MAX_COUNT_HARD_CAP}.`),
+  stripPrefixes: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Strip the timestamp/level prefix (e.g. `04:36:40   Fatal    | `) from each line before pattern matching AND in the returned line/context text. Default false. Turn this on when greping for words that collide with level names (Fatal, Error, Warn) or when you want clean message-only output. Note: when on, your pattern will not match against the prefix — searching for `Fatal` won't find Fatal-level lines.",
+    ),
 };
 
 export function registerGrepTaskLogTool(server: McpServer) {


### PR DESCRIPTION
## Summary

Addresses four pieces of user feedback about MCP tool responses. All four are additive — no breaking changes, no schema rewrites.

- **`grep_task_log`**: adds `stripPrefixes` flag (default `false`). When on, the `HH:MM:SS LEVEL |` prefix is stripped before pattern matching and from returned lines/context, so patterns like `Fatal` or `Error` no longer produce false matches against the level column and output is clean for downstream consumers.
- **`create_release`**: echoes `selectedPackages` (the resolved package versions bound to the new release) in the success response. Pulled from the existing `.get()` round-trip that was already happening for `versionControlReference` — zero new network calls. Saves callers a follow-up `read_resource` to confirm version-template / channel-rule resolution.
- **`deploy_release`**: exposes `taskResourceUri` as a structured field on each `deploymentTasks[]` entry. Previously the URI was templated into `helpText` prose, forcing callers to either parse text or reconstruct the URI. Now it can be fed straight into `read_resource`. Matches the convention already used by `find_interruptions`, `getDeploymentFromUrl`, `find_releases`.
- **`get_task_from_url` / task resource descriptions**: cross-reference each other so callers know `get_task_from_url` returns the same body as the `/tasks/{id}/details` resource and don't double-fetch.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` (unit tests) — 194 pass, 22 files. Five new tests cover `stripPrefixes` (both prefix formats, false-match elimination, untouched lines without prefix, context stripping, default-off preservation).
- [ ] Manual smoke against a live Octopus: call `grep_task_log` with `pattern: "Fatal", stripPrefixes: true` against a failed task — confirm only the message body comes back. Call `create_release` on a project with a templated package version — confirm `selectedPackages` appears in the response and matches `read_resource(resourceUri).SelectedPackages`. Call `deploy_release` — confirm each entry carries `taskResourceUri` and that the URI dereferences via `read_resource` without parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)