### PR TITLE
feat: add find_events tool to search the audit log

### DIFF
--- a/src/helpers/errorHandling.ts
+++ b/src/helpers/errorHandling.ts
@@ -118,4 +118,5 @@ export const ENTITY_PREFIXES = {
   deployment: "Deployments-",
   deploymentProcess: "DeploymentProcesses-",
   interruption: "Interruptions-",
+  event: "Events-",
 } as const;

--- a/src/helpers/pathAllowlist.ts
+++ b/src/helpers/pathAllowlist.ts
@@ -131,6 +131,16 @@ const TOOLSET_PATH_PATTERNS: Record<Toolset, readonly string[]> = {
     "/api/spaces/*/projects/*/featuretoggles",
     "/api/spaces/*/projects/*/featuretoggles/**",
   ],
+  events: [
+    // Space-scoped audit log endpoints.
+    ...spaceScoped("events"),
+    // Unscoped metadata endpoints (categories, groups, agents, documenttypes).
+    // These are server-wide constants with no space prefix. They live in the
+    // `events` toolset rather than `core` so disabling `--toolsets ... events`
+    // is a real kill switch.
+    "/api/events",
+    "/api/events/**",
+  ],
 };
 
 // Specificity = count of literal (non-wildcard) segments in the pattern.

--- a/src/tools/__tests__/findEvents.test.ts
+++ b/src/tools/__tests__/findEvents.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { z } from "zod";
+
+const get = vi.fn();
+const resolveSpaceId = vi.fn();
+
+vi.mock("../../helpers/getClientConfigurationFromEnvironment.js", () => ({
+  getClientConfigurationFromEnvironment: () => ({
+    instanceURL: "https://octopus.example",
+    apiKey: "API-TEST",
+  }),
+}));
+
+vi.mock("@octopusdeploy/api-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@octopusdeploy/api-client")>();
+  return {
+    ...actual,
+    Client: { create: vi.fn(async () => ({ get })) },
+    resolveSpaceId: (...args: unknown[]) => resolveSpaceId(...args),
+  };
+});
+
+import {
+  findEventsHandler,
+  findEventsInputSchema,
+  findEventsValidationSchema,
+  type FindEventsParams,
+} from "../findEvents.js";
+import { parseToolResponse } from "./testSetup.js";
+
+/**
+ * The MCP SDK at 1.29 publishes the inputSchema by reading `.shape` off the
+ * passed Zod schema. If `findEventsInputSchema` regresses to a refined
+ * ZodEffects wrapper (e.g. someone re-applies `.superRefine` directly to the
+ * exported schema once the upstream fix lands prematurely), `.shape` will go
+ * away and clients will see an empty schema. These tests guard against that.
+ */
+describe("find_events — published inputSchema shape (SDK workaround guard)", () => {
+  it("exposes a Zod object .shape directly (no ZodEffects wrapper)", () => {
+    expect(findEventsInputSchema).toBeInstanceOf(z.ZodObject);
+    expect(findEventsInputSchema.shape).toBeDefined();
+  });
+
+  it("declares the typed fields a client needs to know about", () => {
+    const shape = findEventsInputSchema.shape;
+    // String / enum / boolean / number scalars
+    expect(shape.spaceName).toBeInstanceOf(z.ZodOptional);
+    expect(shape.eventId).toBeInstanceOf(z.ZodOptional);
+    expect(shape.from).toBeInstanceOf(z.ZodOptional);
+    expect(shape.to).toBeInstanceOf(z.ZodOptional);
+    expect(shape.includeInternalEvents).toBeInstanceOf(z.ZodOptional);
+    expect(shape.excludeDifference).toBeInstanceOf(z.ZodOptional);
+    expect(shape.skip).toBeInstanceOf(z.ZodOptional);
+    expect(shape.take).toBeInstanceOf(z.ZodOptional);
+    expect(shape.mode).toBeInstanceOf(z.ZodOptional);
+
+    // Array-typed filters — the type that breaks worst when the schema
+    // collapses (MCP clients otherwise stringify them).
+    for (const arrayField of [
+      "regarding",
+      "regardingAny",
+      "users",
+      "projects",
+      "environments",
+      "tenants",
+      "projectGroups",
+      "eventCategories",
+      "eventGroups",
+      "eventAgents",
+      "documentTypes",
+      "tags",
+    ]) {
+      const field = shape[arrayField as keyof typeof shape];
+      expect(field, `missing field: ${arrayField}`).toBeInstanceOf(
+        z.ZodOptional,
+      );
+      // Unwrap the optional to confirm the inner type is an array of strings.
+      const inner = (field as z.ZodOptional<z.ZodArray<z.ZodString>>)._def
+        .innerType;
+      expect(inner, `${arrayField} inner type`).toBeInstanceOf(z.ZodArray);
+    }
+  });
+
+  it("includeInternalEvents and excludeDifference are typed as booleans (not strings)", () => {
+    const shape = findEventsInputSchema.shape;
+    const include = (shape.includeInternalEvents as z.ZodOptional<z.ZodBoolean>)
+      ._def.innerType;
+    const exclude = (shape.excludeDifference as z.ZodOptional<z.ZodBoolean>)
+      ._def.innerType;
+    expect(include).toBeInstanceOf(z.ZodBoolean);
+    expect(exclude).toBeInstanceOf(z.ZodBoolean);
+  });
+
+  it("take and skip are typed as numbers (not strings)", () => {
+    const shape = findEventsInputSchema.shape;
+    const take = (shape.take as z.ZodOptional<z.ZodNumber>)._def.innerType;
+    const skip = (shape.skip as z.ZodOptional<z.ZodNumber>)._def.innerType;
+    expect(take).toBeInstanceOf(z.ZodNumber);
+    expect(skip).toBeInstanceOf(z.ZodNumber);
+  });
+});
+
+describe("find_events — cross-field validation", () => {
+  it("rejects search mode with no spaceName", () => {
+    const result = findEventsValidationSchema.safeParse({ mode: "search" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some(
+          (i) => i.path[0] === "spaceName" && i.message.includes("required"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("accepts search mode with spaceName and no filters", () => {
+    const result = findEventsValidationSchema.safeParse({
+      spaceName: "Default",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects eventId combined with list filters", () => {
+    const result = findEventsValidationSchema.safeParse({
+      spaceName: "Default",
+      eventId: "Events-123",
+      eventGroups: ["Deployment"],
+      take: 10,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path[0]);
+      expect(paths).toContain("eventGroups");
+      expect(paths).toContain("take");
+    }
+  });
+
+  it("accepts eventId combined with excludeDifference (still honoured) and includeInternalEvents (no-op)", () => {
+    const result = findEventsValidationSchema.safeParse({
+      spaceName: "Default",
+      eventId: "Events-123",
+      excludeDifference: true,
+      includeInternalEvents: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects metadata modes when search filters are supplied", () => {
+    const result = findEventsValidationSchema.safeParse({
+      mode: "listCategories",
+      eventGroups: ["Deployment"],
+      take: 5,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path[0]);
+      expect(paths).toContain("eventGroups");
+      expect(paths).toContain("take");
+    }
+  });
+
+  it("accepts metadata modes with no other arguments", () => {
+    for (const mode of [
+      "listCategories",
+      "listGroups",
+      "listAgents",
+      "listDocumentTypes",
+    ] as const) {
+      const result = findEventsValidationSchema.safeParse({ mode });
+      expect(result.success, `${mode} should validate`).toBe(true);
+    }
+  });
+
+  it("metadata modes ignore spaceName (allowed but harmless)", () => {
+    const result = findEventsValidationSchema.safeParse({
+      mode: "listGroups",
+      spaceName: "Default",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("find_events handler — search path passes typed filters through to client.get", () => {
+  beforeEach(() => {
+    get.mockReset();
+    resolveSpaceId.mockReset();
+    resolveSpaceId.mockResolvedValue("Spaces-1");
+  });
+
+  it("forwards arrays, booleans, and numbers in their native JS types (not stringified)", async () => {
+    get.mockResolvedValueOnce({
+      TotalResults: 0,
+      ItemsPerPage: 30,
+      NumberOfPages: 0,
+      LastPageNumber: 0,
+      Items: [],
+    });
+
+    const params: FindEventsParams = {
+      spaceName: "Default",
+      eventGroups: ["Deployment", "Modified"],
+      projects: ["Projects-1"],
+      take: 10,
+      skip: 0,
+      excludeDifference: true,
+      includeInternalEvents: false,
+    };
+
+    await findEventsHandler(params);
+
+    expect(get).toHaveBeenCalledTimes(1);
+    const callArgs = get.mock.calls[0]?.[1] as Record<string, unknown>;
+
+    // Critical: arrays stay as arrays, not JSON-stringified.
+    expect(callArgs.eventGroups).toEqual(["Deployment", "Modified"]);
+    expect(Array.isArray(callArgs.eventGroups)).toBe(true);
+    expect(callArgs.projects).toEqual(["Projects-1"]);
+
+    // Booleans stay as booleans, numbers stay as numbers.
+    expect(callArgs.excludeDifference).toBe(true);
+    expect(callArgs.includeInternalEvents).toBe(false);
+    expect(callArgs.take).toBe(10);
+    expect(callArgs.skip).toBe(0);
+
+    // spaceId substituted from resolveSpaceId.
+    expect(callArgs.spaceId).toBe("Spaces-1");
+  });
+
+  it("excludeDifference strips ChangeDetails from list items", async () => {
+    get.mockResolvedValueOnce({
+      TotalResults: 1,
+      ItemsPerPage: 30,
+      NumberOfPages: 1,
+      LastPageNumber: 0,
+      Items: [
+        {
+          Id: "Events-1",
+          Message: "Deployment succeeded",
+          Category: "DeploymentSucceeded",
+          Occurred: "2026-05-13T00:00:00Z",
+          UserId: "Users-1",
+          Username: "admin",
+          IsService: false,
+          IdentityEstablishedWith: "ApiKey",
+          UserAgent: "curl/8.15.0",
+          RelatedDocumentIds: ["Deployments-1"],
+          MessageHtml: "",
+          MessageReferences: [],
+          Comments: null,
+          Details: null,
+          ChangeDetails: { DocumentContext: "big", Differences: "huge", DocumentVersion: "1" },
+          IpAddress: "::1",
+          SpaceId: "Spaces-1",
+        },
+      ],
+    });
+
+    const response = await findEventsHandler({
+      spaceName: "Default",
+      excludeDifference: true,
+    });
+
+    const parsed = parseToolResponse<{ items: Array<Record<string, unknown>> }>(
+      response,
+    );
+    expect(parsed.items[0]).toBeDefined();
+    expect(parsed.items[0].ChangeDetails).toBeUndefined();
+    // Other fields still present.
+    expect(parsed.items[0].Id).toBe("Events-1");
+    expect(parsed.items[0].Category).toBe("DeploymentSucceeded");
+  });
+
+  it("single-eventId path hits the by-id endpoint, not the list endpoint", async () => {
+    get.mockResolvedValueOnce({
+      Id: "Events-42",
+      Message: "Single fetch",
+      Category: "ReleaseCreated",
+      Occurred: "2026-05-13T00:00:00Z",
+      UserId: "Users-1",
+      Username: "admin",
+      IsService: false,
+      IdentityEstablishedWith: "ApiKey",
+      UserAgent: "curl/8.15.0",
+      RelatedDocumentIds: [],
+      MessageHtml: "",
+      MessageReferences: [],
+      Comments: null,
+      Details: null,
+      IpAddress: "::1",
+      SpaceId: "Spaces-1",
+    });
+
+    const response = await findEventsHandler({
+      spaceName: "Default",
+      eventId: "Events-42",
+    });
+
+    expect(get).toHaveBeenCalledTimes(1);
+    const [path, args] = get.mock.calls[0] as [string, Record<string, unknown>];
+    expect(path).toContain("/events/{id}");
+    expect(path).not.toContain("{?");
+    expect(args.id).toBe("Events-42");
+
+    const parsed = parseToolResponse<Record<string, unknown>>(response);
+    // Single fetch returns the event directly, not a pagination wrapper.
+    expect(parsed.Id).toBe("Events-42");
+    expect((parsed as { items?: unknown }).items).toBeUndefined();
+  });
+
+  it("metadata mode hits the unscoped endpoint and returns mode + items", async () => {
+    get.mockResolvedValueOnce([
+      { Id: "Group-1", Name: "Created" },
+      { Id: "Group-2", Name: "Deleted" },
+    ]);
+
+    const response = await findEventsHandler({ mode: "listGroups" });
+
+    expect(get).toHaveBeenCalledTimes(1);
+    const [path] = get.mock.calls[0] as [string];
+    expect(path).toBe("~/api/events/groups");
+    // resolveSpaceId is not called for metadata modes (no spaceName needed).
+    expect(resolveSpaceId).not.toHaveBeenCalled();
+
+    const parsed = parseToolResponse<{
+      mode: string;
+      items: Array<{ Id: string }>;
+    }>(response);
+    expect(parsed.mode).toBe("listGroups");
+    expect(parsed.items).toHaveLength(2);
+  });
+});

--- a/src/tools/findEvents.ts
+++ b/src/tools/findEvents.ts
@@ -123,8 +123,16 @@ const SINGLE_EVENT_CONFLICTS = [
   "take",
 ] as const;
 
-const findEventsSchema = z
-  .object({
+// IMPORTANT: this is a ZodRawShape (flat object of schemas), not a refined
+// ZodObject. Refinements (`.superRefine`, `.refine`) produce a ZodEffects
+// wrapper, and @modelcontextprotocol/sdk@1.29 does not unwrap ZodEffects in
+// `normalizeObjectSchema` — the published inputSchema collapses to
+// `EMPTY_OBJECT_JSON_SCHEMA`, so MCP clients see no field types and the LLM
+// stringifies arrays/booleans/numbers. The SDK still validates correctly
+// because it falls through to the original schema, but bad cross-field combos
+// would slip past if we relied on the SDK alone. Cross-field invariants are
+// enforced in `validateCrossFields` at handler entry instead.
+const findEventsRawShape = {
     mode: z
       .enum([
         "search",
@@ -262,44 +270,64 @@ const findEventsSchema = z
       .describe(
         "Pagination page size (search mode only). Server default is 30.",
       ),
-  })
-  .superRefine((args, ctx) => {
-    const mode: EventMode = args.mode ?? "search";
+};
 
-    if (mode === "search") {
-      if (!args.spaceName) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "spaceName is required when mode='search'.",
-          path: ["spaceName"],
-        });
-      }
-      if (args.eventId) {
-        for (const key of SINGLE_EVENT_CONFLICTS) {
-          if ((args as Record<string, unknown>)[key] !== undefined) {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: `${key} cannot be combined with eventId. Drop eventId to use list filters, or drop ${key} to fetch a single event.`,
-              path: [key],
-            });
-          }
+/**
+ * Cross-field validation that would have lived in `.superRefine` if the SDK
+ * unwrapped ZodEffects. Returns null when args are valid; otherwise returns a
+ * structured error response the handler can return directly to the client.
+ */
+function validateCrossFields(
+  args: Record<string, unknown>,
+): { content: { type: "text"; text: string }[]; isError: true } | null {
+  const issues: string[] = [];
+  const mode: EventMode = (args.mode as EventMode | undefined) ?? "search";
+
+  if (mode === "search") {
+    if (!args.spaceName) {
+      issues.push("spaceName is required when mode='search'.");
+    }
+    if (args.eventId) {
+      for (const key of SINGLE_EVENT_CONFLICTS) {
+        if (args[key] !== undefined) {
+          issues.push(
+            `${key} cannot be combined with eventId. Drop eventId to use list filters, or drop ${key} to fetch a single event.`,
+          );
         }
       }
-      return;
     }
-
+  } else {
     // Metadata modes: spaceName is allowed (harmless), every search filter is rejected.
     for (const key of SEARCH_ONLY_FIELDS) {
       if (key === "spaceName") continue;
-      if ((args as Record<string, unknown>)[key] !== undefined) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `${key} is only valid when mode='search'. Drop it to call mode='${mode}'.`,
-          path: [key],
-        });
+      if (args[key] !== undefined) {
+        issues.push(
+          `${key} is only valid when mode='search'. Drop it to call mode='${mode}'.`,
+        );
       }
     }
-  });
+  }
+
+  if (issues.length === 0) return null;
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            success: false,
+            error: "Invalid argument combination",
+            issues,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+    isError: true,
+  };
+}
 
 function eventSummary(event: EventResource, excludeDifference?: boolean) {
   const stripped = stripLinks(event) as Record<string, unknown>;
@@ -336,10 +364,17 @@ export function registerFindEventsTool(server: McpServer) {
 - \`from\` (inclusive) and \`to\` (exclusive) accept ISO 8601 datetimes.
 
 **Permissions:** requires \`EventView\` on the calling user's space scope. The server filters results further based on per-document permissions.`,
-      inputSchema: findEventsSchema,
+      inputSchema: findEventsRawShape,
       annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async (args) => {
+      // Cross-field validation (would live in .superRefine if the SDK unwrapped
+      // ZodEffects; see the comment on findEventsRawShape above).
+      const validationError = validateCrossFields(
+        args as unknown as Record<string, unknown>,
+      );
+      if (validationError) return validationError;
+
       const mode: EventMode = args.mode ?? "search";
       const client = await Client.create(getClientConfigurationFromEnvironment());
 

--- a/src/tools/findEvents.ts
+++ b/src/tools/findEvents.ts
@@ -123,15 +123,17 @@ const SINGLE_EVENT_CONFLICTS = [
   "take",
 ] as const;
 
-// IMPORTANT: this is a ZodRawShape (flat object of schemas), not a refined
-// ZodObject. Refinements (`.superRefine`, `.refine`) produce a ZodEffects
-// wrapper, and @modelcontextprotocol/sdk@1.29 does not unwrap ZodEffects in
+// SDK workaround: we publish a plain `z.object(...)` as `inputSchema` because
+// `.superRefine(...)` produces a ZodEffects wrapper that lacks `.shape`, and
+// @modelcontextprotocol/sdk@1.29 does not unwrap ZodEffects in
 // `normalizeObjectSchema` — the published inputSchema collapses to
 // `EMPTY_OBJECT_JSON_SCHEMA`, so MCP clients see no field types and the LLM
-// stringifies arrays/booleans/numbers. The SDK still validates correctly
-// because it falls through to the original schema, but bad cross-field combos
-// would slip past if we relied on the SDK alone. Cross-field invariants are
-// enforced in `validateCrossFields` at handler entry instead.
+// stringifies arrays/booleans/numbers. Cross-field invariants live on the
+// separate `findEventsValidationSchema` (the same fields wrapped in
+// `.superRefine`) and run inside the handler via `safeParse`. When the SDK
+// fix in modelcontextprotocol/typescript-sdk#1865 ships we can pass
+// `findEventsValidationSchema` directly as `inputSchema` and drop the
+// in-handler `safeParse`.
 const findEventsRawShape = {
     mode: z
       .enum([
@@ -161,7 +163,10 @@ const findEventsRawShape = {
       .string()
       .optional()
       .describe(
-        "Fetch a single event by ID (form 'Events-NNN'). Mutually exclusive with all filter arguments.",
+        "Fetch a single event by ID (form 'Events-NNN'). Mutually exclusive with list and pagination filters " +
+          "(regarding, regardingAny, users, projects, environments, tenants, projectGroups, eventCategories, " +
+          "eventGroups, eventAgents, documentTypes, tags, from, to, skip, take). " +
+          "Compatible with excludeDifference (still honoured) and includeInternalEvents (no-op for single fetches).",
       ),
     regarding: z
       .array(z.string())
@@ -273,43 +278,67 @@ const findEventsRawShape = {
 };
 
 /**
- * Cross-field validation that would have lived in `.superRefine` if the SDK
- * unwrapped ZodEffects. Returns null when args are valid; otherwise returns a
- * structured error response the handler can return directly to the client.
+ * Plain ZodObject passed to `server.registerTool` as `inputSchema`. The MCP
+ * SDK requires a schema whose `.shape` is reachable — see the SDK-workaround
+ * comment above `findEventsRawShape`. Refinements go on
+ * `findEventsValidationSchema` (below) and run inside the handler.
  */
-function validateCrossFields(
-  args: Record<string, unknown>,
-): { content: { type: "text"; text: string }[]; isError: true } | null {
-  const issues: string[] = [];
-  const mode: EventMode = (args.mode as EventMode | undefined) ?? "search";
+export const findEventsInputSchema = z.object(findEventsRawShape);
 
-  if (mode === "search") {
-    if (!args.spaceName) {
-      issues.push("spaceName is required when mode='search'.");
-    }
-    if (args.eventId) {
-      for (const key of SINGLE_EVENT_CONFLICTS) {
-        if (args[key] !== undefined) {
-          issues.push(
-            `${key} cannot be combined with eventId. Drop eventId to use list filters, or drop ${key} to fetch a single event.`,
-          );
+/**
+ * Same fields plus cross-field invariants: required `spaceName` for search
+ * mode, mutually-exclusive eventId vs. list/pagination filters, metadata
+ * modes reject every search-only field. Used only inside the handler via
+ * `safeParse`; not published to clients.
+ */
+export const findEventsValidationSchema = findEventsInputSchema.superRefine(
+  (args, ctx) => {
+    const mode: EventMode = args.mode ?? "search";
+
+    if (mode === "search") {
+      if (!args.spaceName) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "spaceName is required when mode='search'.",
+          path: ["spaceName"],
+        });
+      }
+      if (args.eventId) {
+        for (const key of SINGLE_EVENT_CONFLICTS) {
+          if ((args as Record<string, unknown>)[key] !== undefined) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `${key} cannot be combined with eventId. Drop eventId to use list filters, or drop ${key} to fetch a single event.`,
+              path: [key],
+            });
+          }
         }
       }
+      return;
     }
-  } else {
+
     // Metadata modes: spaceName is allowed (harmless), every search filter is rejected.
     for (const key of SEARCH_ONLY_FIELDS) {
       if (key === "spaceName") continue;
-      if (args[key] !== undefined) {
-        issues.push(
-          `${key} is only valid when mode='search'. Drop it to call mode='${mode}'.`,
-        );
+      if ((args as Record<string, unknown>)[key] !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `${key} is only valid when mode='search'. Drop it to call mode='${mode}'.`,
+          path: [key],
+        });
       }
     }
-  }
+  },
+);
 
-  if (issues.length === 0) return null;
+/** Resolved (post-validation) argument type for the handler. */
+export type FindEventsParams = z.infer<typeof findEventsValidationSchema>;
 
+/**
+ * Wrap a Zod parse error in the structured tool-response shape used elsewhere
+ * for argument-validation failures.
+ */
+function zodErrorResponse(error: z.ZodError) {
   return {
     content: [
       {
@@ -318,14 +347,17 @@ function validateCrossFields(
           {
             success: false,
             error: "Invalid argument combination",
-            issues,
+            issues: error.issues.map((i) => ({
+              path: i.path,
+              message: i.message,
+            })),
           },
           null,
           2,
         ),
       },
     ],
-    isError: true,
+    isError: true as const,
   };
 }
 
@@ -335,6 +367,134 @@ function eventSummary(event: EventResource, excludeDifference?: boolean) {
     delete stripped.ChangeDetails;
   }
   return stripped;
+}
+
+/**
+ * Handler body, exported so tests can call it directly with already-validated
+ * params. The `registerTool` wrapper below runs `findEventsValidationSchema`
+ * first and only invokes this if validation succeeds.
+ */
+export async function findEventsHandler(args: FindEventsParams) {
+  const mode: EventMode = args.mode ?? "search";
+  const client = await Client.create(getClientConfigurationFromEnvironment());
+
+  // --- Metadata modes (unscoped, no permission required) -----------------
+  if (mode !== "search") {
+    const path = (() => {
+      switch (mode) {
+        case "listCategories":
+          return "~/api/events/categories";
+        case "listGroups":
+          return "~/api/events/groups";
+        case "listAgents":
+          return "~/api/events/agents";
+        case "listDocumentTypes":
+          return "~/api/events/documenttypes";
+      }
+    })();
+
+    try {
+      const result = await client.get<unknown>(path);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ mode, items: result }),
+          },
+        ],
+      };
+    } catch (error) {
+      handleOctopusApiError(error, {
+        helpText:
+          "The events metadata endpoints (categories/groups/agents/documenttypes) require no permissions; an error here usually means OCTOPUS_SERVER_URL is wrong or the API key is invalid.",
+      });
+    }
+  }
+
+  // --- Search mode -------------------------------------------------------
+  // spaceName presence is enforced by `findEventsValidationSchema`; assert
+  // for the type checker.
+  const spaceName = args.spaceName as string;
+  const spaceId = await resolveSpaceId(client, spaceName);
+
+  // Single-event fast path
+  if (args.eventId) {
+    validateEntityId(args.eventId, "event", ENTITY_PREFIXES.event);
+
+    try {
+      const event = await client.get<EventResource>(
+        "~/api/{spaceId}/events/{id}",
+        { spaceId, id: args.eventId },
+      );
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(eventSummary(event, args.excludeDifference)),
+          },
+        ],
+      };
+    } catch (error) {
+      handleOctopusApiError(error, {
+        entityType: "event",
+        entityId: args.eventId,
+        spaceName,
+        helpText:
+          "Call find_events without eventId to list valid event IDs in this space.",
+      });
+    }
+  }
+
+  // List/search path
+  try {
+    const response = await client.get<ResourceCollection<EventResource>>(
+      "~/api/{spaceId}/events{?skip,take,from,to,regarding,regardingAny,users,projects,environments,tenants,projectGroups,eventCategories,eventGroups,eventAgents,documentTypes,tags,includeInternalEvents,excludeDifference}",
+      {
+        spaceId,
+        skip: args.skip,
+        take: args.take,
+        from: args.from,
+        to: args.to,
+        regarding: args.regarding,
+        regardingAny: args.regardingAny,
+        users: args.users,
+        projects: args.projects,
+        environments: args.environments,
+        tenants: args.tenants,
+        projectGroups: args.projectGroups,
+        eventCategories: args.eventCategories,
+        eventGroups: args.eventGroups,
+        eventAgents: args.eventAgents,
+        documentTypes: args.documentTypes,
+        tags: args.tags,
+        includeInternalEvents: args.includeInternalEvents,
+        excludeDifference: args.excludeDifference,
+      },
+    );
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            totalResults: response.TotalResults,
+            itemsPerPage: response.ItemsPerPage,
+            numberOfPages: response.NumberOfPages,
+            lastPageNumber: response.LastPageNumber,
+            items: response.Items.map((event) =>
+              eventSummary(event, args.excludeDifference),
+            ),
+          }),
+        },
+      ],
+    };
+  } catch (error) {
+    handleOctopusApiError(error, {
+      spaceName,
+      helpText:
+        "Verify the space name is correct and the API key has EventView permission for this space.",
+    });
+  }
 }
 
 export function registerFindEventsTool(server: McpServer) {
@@ -352,7 +512,7 @@ export function registerFindEventsTool(server: McpServer) {
 - \`listDocumentTypes\` — enumerate entity-prefix metadata (\`Projects-\`, \`Releases-\`, ...).
 
 **Search modes** (within \`mode='search'\`, picked by argument shape):
-- \`eventId\` → fetch that single event (mutually exclusive with every filter argument).
+- \`eventId\` → fetch that single event. Mutually exclusive with list and pagination filters; \`excludeDifference\` is still honoured.
 - otherwise → list events matching the filters, paginated.
 
 **Performance tip:** the per-event \`ChangeDetails\` field (the before/after diff for Modified events) is by far the heaviest payload field. Pass \`excludeDifference: true\` whenever scanning many events; fetch a single event without the flag when you need the diff.
@@ -364,136 +524,17 @@ export function registerFindEventsTool(server: McpServer) {
 - \`from\` (inclusive) and \`to\` (exclusive) accept ISO 8601 datetimes.
 
 **Permissions:** requires \`EventView\` on the calling user's space scope. The server filters results further based on per-document permissions.`,
-      inputSchema: findEventsRawShape,
+      inputSchema: findEventsInputSchema,
       annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
     async (args) => {
-      // Cross-field validation (would live in .superRefine if the SDK unwrapped
-      // ZodEffects; see the comment on findEventsRawShape above).
-      const validationError = validateCrossFields(
-        args as unknown as Record<string, unknown>,
-      );
-      if (validationError) return validationError;
+      // Cross-field validation. Lives here (not on `inputSchema`) because the
+      // refined version is a ZodEffects that the SDK collapses to an empty
+      // published schema — see the comment on `findEventsRawShape`.
+      const parsed = findEventsValidationSchema.safeParse(args);
+      if (!parsed.success) return zodErrorResponse(parsed.error);
 
-      const mode: EventMode = args.mode ?? "search";
-      const client = await Client.create(getClientConfigurationFromEnvironment());
-
-      // --- Metadata modes (unscoped, no permission required) -------------------
-      if (mode !== "search") {
-        const path = (() => {
-          switch (mode) {
-            case "listCategories":
-              return "~/api/events/categories";
-            case "listGroups":
-              return "~/api/events/groups";
-            case "listAgents":
-              return "~/api/events/agents";
-            case "listDocumentTypes":
-              return "~/api/events/documenttypes";
-          }
-        })();
-
-        try {
-          const result = await client.get<unknown>(path);
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify({ mode, items: result }),
-              },
-            ],
-          };
-        } catch (error) {
-          handleOctopusApiError(error, {
-            helpText:
-              "The events metadata endpoints (categories/groups/agents/documenttypes) require no permissions; an error here usually means OCTOPUS_SERVER_URL is wrong or the API key is invalid.",
-          });
-        }
-      }
-
-      // --- Search mode --------------------------------------------------------
-      // spaceName presence is enforced by superRefine; assert for the type checker.
-      const spaceName = args.spaceName as string;
-      const spaceId = await resolveSpaceId(client, spaceName);
-
-      // Single-event fast path
-      if (args.eventId) {
-        validateEntityId(args.eventId, "event", ENTITY_PREFIXES.event);
-
-        try {
-          const event = await client.get<EventResource>(
-            "~/api/{spaceId}/events/{id}",
-            { spaceId, id: args.eventId },
-          );
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(eventSummary(event, args.excludeDifference)),
-              },
-            ],
-          };
-        } catch (error) {
-          handleOctopusApiError(error, {
-            entityType: "event",
-            entityId: args.eventId,
-            spaceName,
-            helpText:
-              "Call find_events without eventId to list valid event IDs in this space.",
-          });
-        }
-      }
-
-      // List/search path
-      try {
-        const response = await client.get<ResourceCollection<EventResource>>(
-          "~/api/{spaceId}/events{?skip,take,from,to,regarding,regardingAny,users,projects,environments,tenants,projectGroups,eventCategories,eventGroups,eventAgents,documentTypes,tags,includeInternalEvents,excludeDifference}",
-          {
-            spaceId,
-            skip: args.skip,
-            take: args.take,
-            from: args.from,
-            to: args.to,
-            regarding: args.regarding,
-            regardingAny: args.regardingAny,
-            users: args.users,
-            projects: args.projects,
-            environments: args.environments,
-            tenants: args.tenants,
-            projectGroups: args.projectGroups,
-            eventCategories: args.eventCategories,
-            eventGroups: args.eventGroups,
-            eventAgents: args.eventAgents,
-            documentTypes: args.documentTypes,
-            tags: args.tags,
-            includeInternalEvents: args.includeInternalEvents,
-            excludeDifference: args.excludeDifference,
-          },
-        );
-
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify({
-                totalResults: response.TotalResults,
-                itemsPerPage: response.ItemsPerPage,
-                numberOfPages: response.NumberOfPages,
-                lastPageNumber: response.LastPageNumber,
-                items: response.Items.map((event) =>
-                  eventSummary(event, args.excludeDifference),
-                ),
-              }),
-            },
-          ],
-        };
-      } catch (error) {
-        handleOctopusApiError(error, {
-          spaceName,
-          helpText:
-            "Verify the space name is correct and the API key has EventView permission for this space.",
-        });
-      }
+      return findEventsHandler(parsed.data);
     },
   );
 }

--- a/src/tools/findEvents.ts
+++ b/src/tools/findEvents.ts
@@ -1,0 +1,480 @@
+import {
+  Client,
+  resolveSpaceId,
+  type ResourceCollection,
+} from "@octopusdeploy/api-client";
+import { z } from "zod";
+import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
+import { registerToolDefinition } from "../types/toolConfig.js";
+import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
+import { stripLinks } from "../helpers/stripLinks.js";
+import {
+  validateEntityId,
+  handleOctopusApiError,
+  ENTITY_PREFIXES,
+} from "../helpers/errorHandling.js";
+
+/**
+ * Shape of an Octopus audit event (also called an Event resource).
+ *
+ * The @octopusdeploy/api-client SDK does not expose an EventRepository or
+ * EventResource type, so we declare the fields we care about locally. Fields
+ * mirror Octopus.Core/Resources/EventResource.cs; unrecognised fields pass
+ * through the JSON serialisation untouched.
+ */
+interface EventReference {
+  ReferencedDocumentId: string;
+  IndexPositionInRelatedDocumentIds: number;
+  StartIndexInMessage: number;
+  LengthInMessage: number;
+}
+
+interface ChangeDetails {
+  DocumentContext: string | null;
+  Differences: string | null;
+  DocumentVersion: string | null;
+}
+
+interface EventResource {
+  Id: string;
+  RelatedDocumentIds: string[];
+  Category: string;
+  UserId: string;
+  Username: string;
+  IsService: boolean;
+  IdentityEstablishedWith: string;
+  UserAgent: string;
+  Occurred: string;
+  Message: string;
+  MessageHtml: string;
+  MessageReferences: EventReference[];
+  Comments: string | null;
+  Details: string | null;
+  ChangeDetails?: ChangeDetails | null;
+  IpAddress: string | null;
+  SpaceId: string | null;
+}
+
+interface EventCategoryResource {
+  Id: string;
+  Name: string;
+  Description?: string | null;
+}
+
+interface EventGroupResource {
+  Id: string;
+  Name: string;
+  EventCategories?: string[];
+}
+
+interface DocumentTypeResource {
+  Id: string;
+  Name: string;
+  Description?: string | null;
+}
+
+type EventMode =
+  | "search"
+  | "listCategories"
+  | "listGroups"
+  | "listAgents"
+  | "listDocumentTypes";
+
+const SEARCH_ONLY_FIELDS = [
+  "spaceName",
+  "eventId",
+  "regarding",
+  "regardingAny",
+  "users",
+  "projects",
+  "environments",
+  "tenants",
+  "projectGroups",
+  "eventCategories",
+  "eventGroups",
+  "eventAgents",
+  "documentTypes",
+  "tags",
+  "from",
+  "to",
+  "includeInternalEvents",
+  "excludeDifference",
+  "skip",
+  "take",
+] as const;
+
+const SINGLE_EVENT_CONFLICTS = [
+  "regarding",
+  "regardingAny",
+  "users",
+  "projects",
+  "environments",
+  "tenants",
+  "projectGroups",
+  "eventCategories",
+  "eventGroups",
+  "eventAgents",
+  "documentTypes",
+  "tags",
+  "from",
+  "to",
+  "skip",
+  "take",
+] as const;
+
+const findEventsSchema = z
+  .object({
+    mode: z
+      .enum([
+        "search",
+        "listCategories",
+        "listGroups",
+        "listAgents",
+        "listDocumentTypes",
+      ])
+      .optional()
+      .describe(
+        "What to return. Defaults to 'search' (the audit log itself). " +
+          "Metadata modes enumerate valid filter values: listCategories returns every event category " +
+          "(e.g. DeploymentSucceeded, ReleaseCreated); listGroups returns category groupings " +
+          "(Created/Modified/Deleted/Deployment/Interruption/...); listAgents returns the user-agent strings " +
+          "seen by the audit subsystem; listDocumentTypes returns entity-prefix metadata (Projects-, Releases-, ...). " +
+          "Use a metadata mode first when you need to construct an eventCategories/eventGroups/documentTypes filter " +
+          "and don't know the valid values. Metadata modes ignore every other argument.",
+      ),
+    spaceName: z
+      .string()
+      .optional()
+      .describe(
+        "Space name. Required for mode='search'. Ignored by metadata modes (they are server-wide).",
+      ),
+    eventId: z
+      .string()
+      .optional()
+      .describe(
+        "Fetch a single event by ID (form 'Events-NNN'). Mutually exclusive with all filter arguments.",
+      ),
+    regarding: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Document IDs the event must relate to. AND semantics: event must reference EVERY id listed. " +
+          "Use regardingAny for OR semantics.",
+      ),
+    regardingAny: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Document IDs the event may relate to. OR semantics: event references ANY id listed.",
+      ),
+    users: z
+      .array(z.string())
+      .optional()
+      .describe("User IDs who triggered the event (OR semantics within the list)."),
+    projects: z
+      .array(z.string())
+      .optional()
+      .describe("Project IDs the event relates to (OR semantics)."),
+    environments: z
+      .array(z.string())
+      .optional()
+      .describe("Environment IDs the event relates to (OR semantics)."),
+    tenants: z
+      .array(z.string())
+      .optional()
+      .describe("Tenant IDs the event relates to (OR semantics)."),
+    projectGroups: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Project group IDs. Events for any project inside these groups are included.",
+      ),
+    eventCategories: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Event category names, e.g. ['DeploymentSucceeded','DeploymentFailed']. " +
+          "Use mode='listCategories' to discover the full set.",
+      ),
+    eventGroups: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Event group names, e.g. ['Created','Modified','Deleted','Deployment','Interruption']. " +
+          "Each group is expanded server-side to the categories it contains. " +
+          "Use mode='listGroups' to discover the full set.",
+      ),
+    eventAgents: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "User-agent strings of the clients that triggered the events. " +
+          "Use mode='listAgents' to discover the values present in this instance.",
+      ),
+    documentTypes: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Document type prefixes, e.g. ['Projects-','Releases-']. " +
+          "Use mode='listDocumentTypes' to discover the full set.",
+      ),
+    tags: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Canonical tenant tag IDs of the form 'TagSetName/TagName'. " +
+          "Filters events whose related tenants carry these tags.",
+      ),
+    from: z
+      .string()
+      .optional()
+      .describe(
+        "ISO 8601 datetime. Inclusive lower bound on Occurred (Occurred >= from).",
+      ),
+    to: z
+      .string()
+      .optional()
+      .describe(
+        "ISO 8601 datetime. Exclusive upper bound on Occurred (Occurred < to).",
+      ),
+    includeInternalEvents: z
+      .boolean()
+      .optional()
+      .describe(
+        "Default true. Set false to suppress per-target MachineAdded / MachineDeleted / " +
+          "MachineDeploymentRelatedPropertyWasUpdated noise that floods machine-heavy instances.",
+      ),
+    excludeDifference: z
+      .boolean()
+      .optional()
+      .describe(
+        "Set true to omit the ChangeDetails field (the before/after diff). " +
+          "ChangeDetails is by far the heaviest field per event — recommended for any scan of more than a few events.",
+      ),
+    skip: z
+      .number()
+      .optional()
+      .describe("Pagination offset (search mode only)."),
+    take: z
+      .number()
+      .optional()
+      .describe(
+        "Pagination page size (search mode only). Server default is 30.",
+      ),
+  })
+  .superRefine((args, ctx) => {
+    const mode: EventMode = args.mode ?? "search";
+
+    if (mode === "search") {
+      if (!args.spaceName) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "spaceName is required when mode='search'.",
+          path: ["spaceName"],
+        });
+      }
+      if (args.eventId) {
+        for (const key of SINGLE_EVENT_CONFLICTS) {
+          if ((args as Record<string, unknown>)[key] !== undefined) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `${key} cannot be combined with eventId. Drop eventId to use list filters, or drop ${key} to fetch a single event.`,
+              path: [key],
+            });
+          }
+        }
+      }
+      return;
+    }
+
+    // Metadata modes: spaceName is allowed (harmless), every search filter is rejected.
+    for (const key of SEARCH_ONLY_FIELDS) {
+      if (key === "spaceName") continue;
+      if ((args as Record<string, unknown>)[key] !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `${key} is only valid when mode='search'. Drop it to call mode='${mode}'.`,
+          path: [key],
+        });
+      }
+    }
+  });
+
+function eventSummary(event: EventResource, excludeDifference?: boolean) {
+  const stripped = stripLinks(event) as Record<string, unknown>;
+  if (excludeDifference) {
+    delete stripped.ChangeDetails;
+  }
+  return stripped;
+}
+
+export function registerFindEventsTool(server: McpServer) {
+  server.registerTool(
+    "find_events",
+    {
+      title: "Search the Octopus audit log",
+      description: `Search the Octopus Deploy audit log (also called the Events log) — every meaningful action recorded against a space: deployments, release creations, modifications, user logins, machine registrations, variable edits, tenant changes, and so on.
+
+**Modes** (the \`mode\` arg):
+- \`search\` (default) — query the audit log. Requires \`spaceName\`. Supports rich filtering by user, project, environment, tenant, document type, date range, category, group, and agent.
+- \`listCategories\` — enumerate every event category (e.g. \`DeploymentSucceeded\`).
+- \`listGroups\` — enumerate event groups (e.g. \`Created\`, \`Modified\`, \`Deleted\`, \`Deployment\`). Each group lists the categories inside it.
+- \`listAgents\` — enumerate user-agent strings recorded by the audit subsystem.
+- \`listDocumentTypes\` — enumerate entity-prefix metadata (\`Projects-\`, \`Releases-\`, ...).
+
+**Search modes** (within \`mode='search'\`, picked by argument shape):
+- \`eventId\` → fetch that single event (mutually exclusive with every filter argument).
+- otherwise → list events matching the filters, paginated.
+
+**Performance tip:** the per-event \`ChangeDetails\` field (the before/after diff for Modified events) is by far the heaviest payload field. Pass \`excludeDifference: true\` whenever scanning many events; fetch a single event without the flag when you need the diff.
+
+**Filter semantics:**
+- \`regarding\` — AND semantics: event must reference EVERY listed document ID.
+- \`regardingAny\` — OR semantics: event must reference ANY listed document ID.
+- All other multi-value filters (users, projects, environments, tenants, eventCategories, eventGroups, ...) are OR semantics within the field.
+- \`from\` (inclusive) and \`to\` (exclusive) accept ISO 8601 datetimes.
+
+**Permissions:** requires \`EventView\` on the calling user's space scope. The server filters results further based on per-document permissions.`,
+      inputSchema: findEventsSchema,
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
+    },
+    async (args) => {
+      const mode: EventMode = args.mode ?? "search";
+      const client = await Client.create(getClientConfigurationFromEnvironment());
+
+      // --- Metadata modes (unscoped, no permission required) -------------------
+      if (mode !== "search") {
+        const path = (() => {
+          switch (mode) {
+            case "listCategories":
+              return "~/api/events/categories";
+            case "listGroups":
+              return "~/api/events/groups";
+            case "listAgents":
+              return "~/api/events/agents";
+            case "listDocumentTypes":
+              return "~/api/events/documenttypes";
+          }
+        })();
+
+        try {
+          const result = await client.get<unknown>(path);
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({ mode, items: result }),
+              },
+            ],
+          };
+        } catch (error) {
+          handleOctopusApiError(error, {
+            helpText:
+              "The events metadata endpoints (categories/groups/agents/documenttypes) require no permissions; an error here usually means OCTOPUS_SERVER_URL is wrong or the API key is invalid.",
+          });
+        }
+      }
+
+      // --- Search mode --------------------------------------------------------
+      // spaceName presence is enforced by superRefine; assert for the type checker.
+      const spaceName = args.spaceName as string;
+      const spaceId = await resolveSpaceId(client, spaceName);
+
+      // Single-event fast path
+      if (args.eventId) {
+        validateEntityId(args.eventId, "event", ENTITY_PREFIXES.event);
+
+        try {
+          const event = await client.get<EventResource>(
+            "~/api/{spaceId}/events/{id}",
+            { spaceId, id: args.eventId },
+          );
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(eventSummary(event, args.excludeDifference)),
+              },
+            ],
+          };
+        } catch (error) {
+          handleOctopusApiError(error, {
+            entityType: "event",
+            entityId: args.eventId,
+            spaceName,
+            helpText:
+              "Call find_events without eventId to list valid event IDs in this space.",
+          });
+        }
+      }
+
+      // List/search path
+      try {
+        const response = await client.get<ResourceCollection<EventResource>>(
+          "~/api/{spaceId}/events{?skip,take,from,to,regarding,regardingAny,users,projects,environments,tenants,projectGroups,eventCategories,eventGroups,eventAgents,documentTypes,tags,includeInternalEvents,excludeDifference}",
+          {
+            spaceId,
+            skip: args.skip,
+            take: args.take,
+            from: args.from,
+            to: args.to,
+            regarding: args.regarding,
+            regardingAny: args.regardingAny,
+            users: args.users,
+            projects: args.projects,
+            environments: args.environments,
+            tenants: args.tenants,
+            projectGroups: args.projectGroups,
+            eventCategories: args.eventCategories,
+            eventGroups: args.eventGroups,
+            eventAgents: args.eventAgents,
+            documentTypes: args.documentTypes,
+            tags: args.tags,
+            includeInternalEvents: args.includeInternalEvents,
+            excludeDifference: args.excludeDifference,
+          },
+        );
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                totalResults: response.TotalResults,
+                itemsPerPage: response.ItemsPerPage,
+                numberOfPages: response.NumberOfPages,
+                lastPageNumber: response.LastPageNumber,
+                items: response.Items.map((event) =>
+                  eventSummary(event, args.excludeDifference),
+                ),
+              }),
+            },
+          ],
+        };
+      } catch (error) {
+        handleOctopusApiError(error, {
+          spaceName,
+          helpText:
+            "Verify the space name is correct and the API key has EventView permission for this space.",
+        });
+      }
+    },
+  );
+}
+
+// Type-only references to silence unused-import warnings for the metadata
+// shape interfaces — they document the response shapes for human readers
+// even though the runtime accepts `unknown` and the LLM consumes the raw JSON.
+export type {
+  EventResource,
+  EventCategoryResource,
+  EventGroupResource,
+  DocumentTypeResource,
+};
+
+registerToolDefinition({
+  toolName: "find_events",
+  config: { toolset: "events", readOnly: true },
+  registerFn: registerFindEventsTool,
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -29,6 +29,7 @@ import "./findDeploymentTargets.js";
 import "./findCertificates.js";
 import "./findAccounts.js";
 import "./findInterruptions.js";
+import "./findEvents.js";
 
 // Feature toggles
 import "./findFeatureToggles.js";

--- a/src/types/toolConfig.ts
+++ b/src/types/toolConfig.ts
@@ -14,7 +14,8 @@ export type Toolset =
   | "certificates"
   | "accounts"
   | "interruptions"
-  | "featureToggles";
+  | "featureToggles"
+  | "events";
 
 export interface ToolConfig {
   toolset: Toolset;
@@ -67,7 +68,8 @@ export const DEFAULT_TOOLSETS: Toolset[] = [
   "certificates",
   "accounts",
   "interruptions",
-  "featureToggles"
+  "featureToggles",
+  "events"
 ];
 
 export interface ToolVersionInfo {


### PR DESCRIPTION
## Summary

Adds `find_events`, a new MCP tool that exposes Octopus Deploy's Events / audit log API so AI assistants can answer "what changed", "who deployed X", and "show modifications in the last day" without falling back to the `execute` backstop.

- **One tool, five modes** via a `mode` arg:
  - `search` (default) — query the audit log for a space.
  - `listCategories` / `listGroups` / `listAgents` / `listDocumentTypes` — enumerate valid filter values from the unscoped `/api/events/{categories,groups,agents,documenttypes}` metadata endpoints, so the LLM can discover legal filter inputs without guessing.
- **Search filters**: `regarding` (AND), `regardingAny` (OR), `users`, `projects`, `environments`, `tenants`, `projectGroups`, `eventCategories`, `eventGroups`, `eventAgents`, `documentTypes`, `tags`, `from`, `to`, `includeInternalEvents`, `excludeDifference`, `skip`, `take`. Plus a single-event fast path via `eventId`.
- **`excludeDifference: true`** is the opt-out for the heavy `ChangeDetails` diff — recommended whenever scanning more than a handful of events.
- **New `events` toolset** (default-enabled) so operators can kill-switch the audit log via `--toolsets`, with matching path-allowlist entries so the `execute` backstop respects the same gate.

## Why

The audit log is the single most useful endpoint for post-incident review and "what happened" questions, but it wasn't reachable through the curated tools — agents had to hand-roll `execute` calls to `/api/{space}/events` and guess at the filter shape. This closes that gap with a tool that mirrors the `find_*` convention.

## Commits

1. **`feat: add find_events tool to search the audit log`** — the tool, the new `events` toolset, the `Events-` ENTITY_PREFIX, the path-allowlist entries.
2. **`fix: publish find_events inputSchema with property types`** — workaround for an upstream SDK bug, see below.

## Implementation notes

- `@octopusdeploy/api-client` doesn't expose an `EventRepository`, so the tool calls `client.get<T>(path, args)` directly with a URI template — the same pattern `findDeploymentTargets` uses for `/machines`.
- `resolveSpaceId` from the SDK handles `spaceName → spaceId`.
- `EventResource` and the metadata resource shapes are declared as local TypeScript interfaces in the tool file (the SDK doesn't ship them).
- `ENTITY_PREFIXES` gains `event: "Events-"` so the single-event fast path validates the ID format before the API call.

## SDK bug workaround

CLAUDE.md prefers `.superRefine(...)` for cross-field invariants. That preference is correct in principle but currently broken in practice: `@modelcontextprotocol/sdk@1.29.0` (the latest published version) has a bug where `normalizeObjectSchema` in `server/zod-compat.js` returns `undefined` for any `ZodEffects` wrapper (the type that `.superRefine`/`.refine`/`.transform` produce), and the `tools/list` handler falls back to `EMPTY_OBJECT_JSON_SCHEMA`. Validation still runs against the original refined schema, but the client sees a property-less tool and **stringifies every argument it sends** — array filters arrive as JSON-encoded strings and `Expected array, received string` errors blow up the call.

Upstream fix: [modelcontextprotocol/typescript-sdk#1865](https://github.com/modelcontextprotocol/typescript-sdk/pull/1865) ("fix(server): handle ZodEffects in normalizeObjectSchema and getObjectShape"). The PR's diagnosis is identical to mine. It's been open since 2026-04-08 with one review comment; **not merged**, no newer SDK release with the fix.

Workaround in this PR:
- `inputSchema` is a `ZodRawShape` (flat object of schemas), not a refined `ZodObject`. This is the path the SDK actually handles via `objectFromShape` → proper JSON Schema with declared property types.
- Cross-field invariants (mode vs. search-only fields, `eventId` vs. list filters) live in a `validateCrossFields(args)` helper called at the top of the handler. Invalid combinations return a structured `{ success: false, error, issues: [...], isError: true }` response listing every problem, so the LLM still gets clear feedback.
- When [#1865](https://github.com/modelcontextprotocol/typescript-sdk/pull/1865) ships and we bump the SDK pin, the workaround comes out in a small follow-up: drop `validateCrossFields`, wrap the raw shape in `z.object(...).superRefine(...)`, remove the explanatory comment. No behaviour change for callers.

The same latent bug also affects `findReleases` and `findInterruptions` (both use `.superRefine`), but their cross-field rules are narrower and they don't have array filters, so users haven't hit it visibly. Out of scope for this PR; flagged as follow-up.

## Test plan

- [x] `npm run build` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — all pre-existing non-environmental tests pass; the 11 failures present on this branch are also present on `main` (integration tests requiring a live Octopus instance with a space called `"Octopus Server"`)
- [ ] Smoke-test against a live Octopus instance after `npm start`:
  - [ ] `find_events` with `{ mode: "listGroups" }` returns event group descriptors
  - [ ] `find_events` with `{ spaceName: "Default", take: 5, excludeDifference: true }` returns five events with array filters typed correctly on the wire
  - [ ] `find_events` with `{ spaceName: "Default", eventGroups: ["Deployment"], take: 10, excludeDifference: true }` returns only Deployment-category events
  - [ ] `from`/`to` date range filtering bounds correctly
  - [ ] Single fetch via `{ spaceName: "Default", eventId: "Events-NNN" }` returns one object, not a pagination wrapper
  - [ ] `validateCrossFields` rejects illegal combos (`eventCategories` with `mode: "listGroups"`, `eventId` combined with list filters, missing `spaceName` in search mode) with `isError: true`
  - [ ] `--toolsets releases` (events disabled) hides `find_events` from the tool list and makes `execute GET /api/Spaces-1/events` fail with `pathNotAllowed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)