### PR TITLE
fix: support Config-as-Code projects in runbook tools

### DIFF
--- a/src/helpers/vcsProjectHelpers.ts
+++ b/src/helpers/vcsProjectHelpers.ts
@@ -8,15 +8,15 @@ export async function getProjectBranches(
   options?: GetProjectBranchesOptions
 ): Promise<ResourceCollection<GitBranch>> {
   const queryParams: Record<string, string> = {};
-  
+
   if (options?.searchByName) {
     queryParams.searchByName = options.searchByName;
   }
-  
+
   if (options?.skip !== undefined) {
     queryParams.skip = options.skip.toString();
   }
-  
+
   if (options?.take !== undefined) {
     queryParams.take = options.take.toString();
   }
@@ -31,4 +31,23 @@ export async function getProjectBranches(
   );
 
   return result;
+}
+
+// Mirrors the server-side extension methods in
+// Octopus.Core.Model.Projects.PersistenceSettingsExtensionMethods. The
+// api-client's PersistenceSettings discriminated union doesn't type
+// ConversionState, so we walk it as unknown.
+
+export function hasRunbooksInGit(persistence: unknown): boolean {
+  if (typeof persistence !== "object" || persistence === null) return false;
+  const conversionState = (persistence as Record<string, unknown>).ConversionState;
+  if (typeof conversionState !== "object" || conversionState === null) return false;
+  return (conversionState as Record<string, unknown>).RunbooksAreInGit === true;
+}
+
+export function hasVariablesInGit(persistence: unknown): boolean {
+  if (typeof persistence !== "object" || persistence === null) return false;
+  const conversionState = (persistence as Record<string, unknown>).ConversionState;
+  if (typeof conversionState !== "object" || conversionState === null) return false;
+  return (conversionState as Record<string, unknown>).VariablesAreInGit === true;
 }

--- a/src/resources/__tests__/dispatch.test.ts
+++ b/src/resources/__tests__/dispatch.test.ts
@@ -132,6 +132,49 @@ describe("dispatchOctopusUri", () => {
     expect(descriptor.read).not.toHaveBeenCalled();
   });
 
+  it("routes DB and CaC runbook URIs to their distinct descriptors without cross-talk (different segment counts)", async () => {
+    const dbRunbook = makeDescriptor({
+      name: "runbook",
+      toolset: "runbooks",
+      uriTemplate: "octopus://spaces/{spaceName}/runbooks/{runbookId}",
+    });
+    const cacRunbook = makeDescriptor({
+      name: "runbook-git",
+      toolset: "runbooks",
+      uriTemplate:
+        "octopus://spaces/{spaceName}/projects/{projectSlug}/{gitRef}/runbooks/{runbookSlug}",
+    });
+    registerResourceDescriptor(dbRunbook);
+    registerResourceDescriptor(cacRunbook);
+
+    // DB URI matches only the DB descriptor.
+    const dbPayload = await dispatchOctopusUri(
+      "octopus://spaces/Default/runbooks/Runbooks-7",
+    );
+    expect(dbPayload).not.toBeNull();
+    expect(JSON.parse(dbPayload!.text)).toEqual({
+      spaceName: "Default",
+      runbookId: "Runbooks-7",
+    });
+    expect(dbRunbook.read).toHaveBeenCalledTimes(1);
+    expect(cacRunbook.read).not.toHaveBeenCalled();
+
+    // CaC URI matches only the CaC descriptor.
+    const cacPayload = await dispatchOctopusUri(
+      "octopus://spaces/Default/projects/cac-proj/main/runbooks/provision-db",
+    );
+    expect(cacPayload).not.toBeNull();
+    expect(JSON.parse(cacPayload!.text)).toEqual({
+      spaceName: "Default",
+      projectSlug: "cac-proj",
+      gitRef: "main",
+      runbookSlug: "provision-db",
+    });
+    expect(cacRunbook.read).toHaveBeenCalledTimes(1);
+    // DB descriptor was not called a second time.
+    expect(dbRunbook.read).toHaveBeenCalledTimes(1);
+  });
+
   describe("toolset filtering", () => {
     afterEach(() => {
       // Reset to "all enabled" so other test files aren't affected by leaked state.

--- a/src/resources/runbook.ts
+++ b/src/resources/runbook.ts
@@ -1,5 +1,7 @@
 import {
   Client,
+  ProjectRepository,
+  RunbookRepository,
   resolveSpaceId,
   type Runbook,
 } from "@octopusdeploy/api-client";
@@ -18,7 +20,7 @@ registerResourceDescriptor({
   toolset: "runbooks",
   title: "Octopus runbook",
   description:
-    "Full runbook object for a given runbook ID in a space. Body shape mirrors the find_runbooks tool output for a single runbook, plus runtime policy fields (ConnectivityPolicy, DefaultGuidedFailureMode, RunRetentionPolicy) that the slim summary omits.",
+    "Full runbook object for a given runbook ID in a space (DB-backed projects). Body shape mirrors the find_runbooks tool output for a single runbook, plus runtime policy fields (ConnectivityPolicy, DefaultGuidedFailureMode, RunRetentionPolicy) that the slim summary omits. For Config-as-Code runbooks see the runbook-git URI form.",
   mimeType: "application/json",
   read: async ({ spaceName, runbookId }) => {
     validateEntityId(runbookId, "runbook", ENTITY_PREFIXES.runbook);
@@ -43,6 +45,49 @@ registerResourceDescriptor({
         entityId: runbookId,
         spaceName,
         helpText: "Use find_runbooks to find valid runbook IDs.",
+      });
+    }
+  },
+});
+
+registerResourceDescriptor({
+  name: "runbook-git",
+  uriTemplate:
+    "octopus://spaces/{spaceName}/projects/{projectSlug}/{gitRef}/runbooks/{runbookSlug}",
+  toolset: "runbooks",
+  title: "Octopus runbook (Config-as-Code)",
+  description:
+    "Full runbook object for a Config-as-Code runbook at a specific gitRef. Body shape mirrors the find_runbooks tool output for a single runbook, plus runtime policy fields. The DB-backed form is the runbook URI without project/gitRef segments.",
+  mimeType: "application/json",
+  read: async ({ spaceName, projectSlug, gitRef, runbookSlug }) => {
+    try {
+      const client = await Client.create(
+        getClientConfigurationFromEnvironment(),
+      );
+      const project = await new ProjectRepository(client, spaceName).get(
+        projectSlug,
+      );
+      const runbookRepository = new RunbookRepository(
+        client,
+        spaceName,
+        project,
+      );
+      const runbook = await runbookRepository.getWithGitRef(
+        runbookSlug,
+        gitRef,
+      );
+
+      return {
+        mimeType: "application/json",
+        text: JSON.stringify(stripLinks(runbook)),
+      };
+    } catch (error) {
+      handleOctopusApiError(error, {
+        entityType: "runbook",
+        entityId: runbookSlug,
+        spaceName,
+        helpText:
+          "Use find_runbooks with the same gitRef to find valid CaC runbook slugs.",
       });
     }
   },

--- a/src/tools/__tests__/findRunbooks.handler.test.ts
+++ b/src/tools/__tests__/findRunbooks.handler.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const projectList = vi.fn();
+const runbookGet = vi.fn();
+const runbookList = vi.fn();
+const runbookGetWithGitRef = vi.fn();
+const clientGet = vi.fn();
+const resolveSpaceId = vi.fn();
+
+vi.mock("../../helpers/getClientConfigurationFromEnvironment.js", () => ({
+  getClientConfigurationFromEnvironment: () => ({
+    instanceURL: "https://octopus.example",
+    apiKey: "API-TEST",
+  }),
+}));
+
+vi.mock("@octopusdeploy/api-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@octopusdeploy/api-client")>();
+  // Arrow functions cannot be invoked with `new`; use regular function
+  // expressions so the production code's `new ProjectRepository(...)` works.
+  return {
+    ...actual,
+    Client: { create: vi.fn(async () => ({ get: clientGet })) },
+    resolveSpaceId: (...args: unknown[]) => resolveSpaceId(...args),
+    ProjectRepository: function () {
+      return { list: projectList };
+    },
+    RunbookRepository: function () {
+      return {
+        get: runbookGet,
+        list: runbookList,
+        getWithGitRef: runbookGetWithGitRef,
+      };
+    },
+  };
+});
+
+import {
+  findRunbooksHandler,
+  findRunbooksSchema,
+} from "../findRunbooks.js";
+import { parseToolResponse } from "./testSetup.js";
+
+const dbProject = {
+  Id: "Projects-1",
+  Name: "DbProj",
+  Slug: "db-proj",
+  IsVersionControlled: false,
+  PersistenceSettings: { Type: "Database" as const },
+};
+
+const cacProject = {
+  Id: "Projects-2",
+  Name: "CaCProj",
+  Slug: "cac-proj",
+  IsVersionControlled: true,
+  PersistenceSettings: {
+    Type: "VersionControlled" as const,
+    Url: "https://github.com/example/cac.git",
+    DefaultBranch: "main",
+    BasePath: ".octopus",
+    Credentials: { Type: "Anonymous" },
+    ConversionState: { RunbooksAreInGit: true },
+  },
+};
+
+const sampleDbRunbook = {
+  Id: "Runbooks-7",
+  Name: "Smoke Test",
+  Description: "Quick smoke",
+  ProjectId: "Projects-1",
+  RunbookProcessId: "RunbookProcess-Runbooks-7",
+  PublishedRunbookSnapshotId: "RunbookSnapshots-1",
+  MultiTenancyMode: "Untenanted",
+  EnvironmentScope: "All",
+  Environments: [],
+};
+
+const sampleCacRunbook = {
+  Id: "Runbooks-8",
+  Name: "Provision DB",
+  Description: "Spin up DB",
+  ProjectId: "Projects-2",
+  RunbookProcessId: "RunbookProcess-Runbooks-8",
+  // CaC wire response — Slug is present even though api-client's Runbook type
+  // doesn't declare it.
+  Slug: "provision-db",
+  PublishedRunbookSnapshotId: null,
+  MultiTenancyMode: "Untenanted",
+  EnvironmentScope: "All",
+  Environments: [],
+};
+
+function mockProject(project: typeof dbProject | typeof cacProject) {
+  projectList.mockResolvedValueOnce({ Items: [project] });
+}
+
+describe("findRunbooksHandler", () => {
+  beforeEach(() => {
+    projectList.mockReset();
+    runbookGet.mockReset();
+    runbookList.mockReset();
+    runbookGetWithGitRef.mockReset();
+    clientGet.mockReset();
+    resolveSpaceId.mockReset();
+    resolveSpaceId.mockResolvedValue("Spaces-1");
+  });
+
+  it("DB project listing returns the legacy summary shape with publishedRunbookSnapshotId and the DB resourceUri", async () => {
+    mockProject(dbProject);
+    runbookList.mockResolvedValueOnce({
+      TotalResults: 1,
+      ItemsPerPage: 30,
+      NumberOfPages: 1,
+      LastPageNumber: 0,
+      Items: [sampleDbRunbook],
+    });
+
+    const response = await findRunbooksHandler({
+      spaceName: "Default",
+      projectName: "DbProj",
+    });
+
+    const body = parseToolResponse<{
+      items: Array<{
+        publishedRunbookSnapshotId?: string;
+        gitRef?: string;
+        resourceUri: string;
+      }>;
+    }>(response);
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].publishedRunbookSnapshotId).toBe("RunbookSnapshots-1");
+    expect(body.items[0].gitRef).toBeUndefined();
+    expect(body.items[0].resourceUri).toBe(
+      "octopus://spaces/Default/runbooks/Runbooks-7",
+    );
+    expect(runbookGetWithGitRef).not.toHaveBeenCalled();
+    expect(clientGet).not.toHaveBeenCalled();
+  });
+
+  it("DB project + runbookId returns the legacy single-fetch shape", async () => {
+    mockProject(dbProject);
+    runbookGet.mockResolvedValueOnce(sampleDbRunbook);
+
+    const response = await findRunbooksHandler({
+      spaceName: "Default",
+      projectName: "DbProj",
+      runbookId: "Runbooks-7",
+    });
+
+    const body = parseToolResponse<{
+      publishedRunbookSnapshotId?: string;
+      resourceUri: string;
+    }>(response);
+    expect(body.publishedRunbookSnapshotId).toBe("RunbookSnapshots-1");
+    expect(body.resourceUri).toBe(
+      "octopus://spaces/Default/runbooks/Runbooks-7",
+    );
+    expect(runbookGet).toHaveBeenCalledWith("Runbooks-7");
+  });
+
+  it("CaC project without gitRef returns an error mentioning DefaultBranch and get_branches without calling the runbook API", async () => {
+    mockProject(cacProject);
+
+    const response = await findRunbooksHandler({
+      spaceName: "Default",
+      projectName: "CaCProj",
+    });
+
+    const body = parseToolResponse<{ success: boolean; error: string }>(
+      response,
+    );
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("stores its runbooks in Git");
+    expect(body.error).toContain("'main'");
+    expect(body.error).toContain("get_branches");
+    expect(runbookList).not.toHaveBeenCalled();
+    expect(runbookGetWithGitRef).not.toHaveBeenCalled();
+    expect(clientGet).not.toHaveBeenCalled();
+  });
+
+  it("CaC project + gitRef listing hits the git URL and returns CaC summaries with gitRef and CaC resourceUri (no publishedRunbookSnapshotId)", async () => {
+    mockProject(cacProject);
+    clientGet.mockResolvedValueOnce({
+      TotalResults: 1,
+      ItemsPerPage: 30,
+      NumberOfPages: 1,
+      LastPageNumber: 0,
+      Items: [sampleCacRunbook],
+    });
+
+    const response = await findRunbooksHandler({
+      spaceName: "Default",
+      projectName: "CaCProj",
+      gitRef: "main",
+    });
+
+    expect(clientGet).toHaveBeenCalledTimes(1);
+    const [url, vars] = clientGet.mock.calls[0];
+    expect(url).toContain("/projects/{projectId}/{gitRef}/runbooks");
+    expect(vars).toMatchObject({
+      spaceId: "Spaces-1",
+      projectId: "Projects-2",
+      gitRef: "main",
+    });
+
+    const body = parseToolResponse<{
+      items: Array<{
+        gitRef: string;
+        publishedRunbookSnapshotId?: string;
+        resourceUri?: string;
+      }>;
+    }>(response);
+    expect(body.items[0].gitRef).toBe("main");
+    expect(body.items[0].publishedRunbookSnapshotId).toBeUndefined();
+    expect(body.items[0].resourceUri).toBe(
+      "octopus://spaces/Default/projects/cac-proj/main/runbooks/provision-db",
+    );
+  });
+
+  it("CaC project + gitRef + runbookSlug calls getWithGitRef(slug, gitRef) and returns the single-fetch CaC summary", async () => {
+    mockProject(cacProject);
+    runbookGetWithGitRef.mockResolvedValueOnce(sampleCacRunbook);
+
+    const response = await findRunbooksHandler({
+      spaceName: "Default",
+      projectName: "CaCProj",
+      gitRef: "main",
+      runbookSlug: "provision-db",
+    });
+
+    expect(runbookGetWithGitRef).toHaveBeenCalledWith("provision-db", "main");
+    const body = parseToolResponse<{ gitRef: string; resourceUri: string }>(
+      response,
+    );
+    expect(body.gitRef).toBe("main");
+    expect(body.resourceUri).toBe(
+      "octopus://spaces/Default/projects/cac-proj/main/runbooks/provision-db",
+    );
+  });
+
+  it("CaC project + gitRef when the wire response omits Slug falls back to omitting resourceUri instead of fabricating one", async () => {
+    mockProject(cacProject);
+    const cacRunbookWithoutSlug = { ...sampleCacRunbook };
+    delete (cacRunbookWithoutSlug as { Slug?: string }).Slug;
+    runbookGetWithGitRef.mockResolvedValueOnce(cacRunbookWithoutSlug);
+
+    const response = await findRunbooksHandler({
+      spaceName: "Default",
+      projectName: "CaCProj",
+      gitRef: "main",
+      runbookSlug: "provision-db",
+    });
+
+    const body = parseToolResponse<{
+      gitRef: string;
+      resourceUri?: string;
+    }>(response);
+    expect(body.gitRef).toBe("main");
+    expect(body.resourceUri).toBeUndefined();
+  });
+
+  it("DB project + gitRef is rejected before calling the runbook API (mismatched route would otherwise silently misbehave)", async () => {
+    mockProject(dbProject);
+
+    const response = await findRunbooksHandler({
+      spaceName: "Default",
+      projectName: "DbProj",
+      gitRef: "main",
+    });
+
+    const body = parseToolResponse<{ success: boolean; error: string }>(
+      response,
+    );
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("stores its runbooks in the database");
+    expect(runbookList).not.toHaveBeenCalled();
+    expect(clientGet).not.toHaveBeenCalled();
+  });
+
+  describe("schema-level rejections", () => {
+    it("rejects runbookId + gitRef (a runbook ID belongs to a DB project; gitRef belongs to a CaC project)", () => {
+      const result = findRunbooksSchema.safeParse({
+        spaceName: "Default",
+        projectName: "Anything",
+        runbookId: "Runbooks-1",
+        gitRef: "main",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.map((i) => i.message).join("\n"),
+        ).toMatch(/gitRef cannot be combined with runbookId/);
+      }
+    });
+
+    it("rejects runbookSlug without gitRef (CaC slugs aren't unique without a ref)", () => {
+      const result = findRunbooksSchema.safeParse({
+        spaceName: "Default",
+        projectName: "Anything",
+        runbookSlug: "provision-db",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.map((i) => i.message).join("\n"),
+        ).toMatch(/runbookSlug requires gitRef/);
+      }
+    });
+
+    it("rejects runbookId + runbookSlug (the two ID forms are mutually exclusive)", () => {
+      const result = findRunbooksSchema.safeParse({
+        spaceName: "Default",
+        projectName: "Anything",
+        runbookId: "Runbooks-1",
+        runbookSlug: "provision-db",
+        gitRef: "main",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.map((i) => i.message).join("\n"),
+        ).toMatch(/mutually exclusive/);
+      }
+    });
+
+    it("still rejects runbookId + partialName (existing rule, unchanged)", () => {
+      const result = findRunbooksSchema.safeParse({
+        spaceName: "Default",
+        projectName: "Anything",
+        runbookId: "Runbooks-1",
+        partialName: "smoke",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/tools/__tests__/runRunbook.handler.test.ts
+++ b/src/tools/__tests__/runRunbook.handler.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const projectList = vi.fn();
+const runbookRunCreate = vi.fn();
+const runbookRunCreateGit = vi.fn();
+
+vi.mock("../../helpers/getClientConfigurationFromEnvironment.js", () => ({
+  getClientConfigurationFromEnvironment: () => ({
+    instanceURL: "https://octopus.example",
+    apiKey: "API-TEST",
+  }),
+}));
+
+vi.mock("@octopusdeploy/api-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@octopusdeploy/api-client")>();
+  // Arrow functions cannot be invoked with `new`; use regular function
+  // expressions so the production code's `new ProjectRepository(...)` works.
+  return {
+    ...actual,
+    Client: { create: vi.fn(async () => ({})) },
+    ProjectRepository: function () {
+      return { list: projectList };
+    },
+    RunbookRunRepository: function () {
+      return {
+        create: runbookRunCreate,
+        createGit: runbookRunCreateGit,
+      };
+    },
+  };
+});
+
+import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { runRunbookHandler, runRunbookSchema } from "../runRunbook.js";
+import { assertToolResponse, parseToolResponse } from "./testSetup.js";
+
+function makeServer(opts: {
+  elicitResult?: { action: "accept" | "decline" | "cancel" };
+} = {}): McpServer {
+  return {
+    server: {
+      elicitInput: vi.fn(async () => opts.elicitResult ?? { action: "accept" }),
+      getClientCapabilities: vi.fn(() => ({ elicitation: {} })),
+    },
+  } as unknown as McpServer;
+}
+
+const dbProject = {
+  Id: "Projects-1",
+  Name: "DbProj",
+  Slug: "db-proj",
+  IsVersionControlled: false,
+  PersistenceSettings: { Type: "Database" as const },
+};
+
+const cacProject = {
+  Id: "Projects-2",
+  Name: "CaCProj",
+  Slug: "cac-proj",
+  IsVersionControlled: true,
+  PersistenceSettings: {
+    Type: "VersionControlled" as const,
+    Url: "https://github.com/example/cac.git",
+    DefaultBranch: "main",
+    BasePath: ".octopus",
+    Credentials: { Type: "Anonymous" },
+    ConversionState: { RunbooksAreInGit: true },
+  },
+};
+
+function mockProject(project: typeof dbProject | typeof cacProject) {
+  projectList.mockResolvedValueOnce({ Items: [project] });
+}
+
+const sampleTaskResponse = {
+  RunbookRunServerTasks: [
+    { ServerTaskId: "ServerTasks-1", RunbookRunId: "RunbookRuns-1" },
+  ],
+};
+
+describe("runRunbookHandler", () => {
+  beforeEach(() => {
+    projectList.mockReset();
+    runbookRunCreate.mockReset();
+    runbookRunCreateGit.mockReset();
+  });
+
+  it("DB project without snapshot uses create() and does NOT mention gitRef in the success response", async () => {
+    mockProject(dbProject);
+    runbookRunCreate.mockResolvedValueOnce(sampleTaskResponse);
+
+    const response = await runRunbookHandler(makeServer(), {
+      spaceName: "Default",
+      projectName: "DbProj",
+      runbookName: "Smoke Test",
+      environmentNames: ["Development"],
+    });
+
+    expect(runbookRunCreate).toHaveBeenCalledTimes(1);
+    expect(runbookRunCreateGit).not.toHaveBeenCalled();
+    const [command] = runbookRunCreate.mock.calls[0];
+    expect(command).not.toHaveProperty("Snapshot");
+    expect(command.RunbookName).toBe("Smoke Test");
+
+    const body = parseToolResponse<{ success: boolean; gitRef?: string }>(
+      response,
+    );
+    expect(body.success).toBe(true);
+    expect(body.gitRef).toBeUndefined();
+  });
+
+  it("DB project with runbookSnapshotId passes Snapshot through to create()", async () => {
+    mockProject(dbProject);
+    runbookRunCreate.mockResolvedValueOnce(sampleTaskResponse);
+
+    await runRunbookHandler(makeServer(), {
+      spaceName: "Default",
+      projectName: "DbProj",
+      runbookName: "Smoke Test",
+      environmentNames: ["Development"],
+      runbookSnapshotId: "RunbookSnapshots-9",
+    });
+
+    expect(runbookRunCreate).toHaveBeenCalledTimes(1);
+    const [command] = runbookRunCreate.mock.calls[0];
+    expect(command.Snapshot).toBe("RunbookSnapshots-9");
+  });
+
+  it("CaC project without gitRef returns an error mentioning DefaultBranch and never calls create/createGit", async () => {
+    mockProject(cacProject);
+
+    const response = await runRunbookHandler(makeServer(), {
+      spaceName: "Default",
+      projectName: "CaCProj",
+      runbookName: "Provision DB",
+      environmentNames: ["Development"],
+    });
+
+    const body = parseToolResponse<{ success: boolean; error: string }>(
+      response,
+    );
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("stores its runbooks in Git");
+    expect(body.error).toContain("'main'");
+    expect(runbookRunCreate).not.toHaveBeenCalled();
+    expect(runbookRunCreateGit).not.toHaveBeenCalled();
+  });
+
+  it("CaC project + gitRef uses createGit(command, gitRef); the command carries no Snapshot field; response echoes gitRef", async () => {
+    mockProject(cacProject);
+    runbookRunCreateGit.mockResolvedValueOnce(sampleTaskResponse);
+
+    const response = await runRunbookHandler(makeServer(), {
+      spaceName: "Default",
+      projectName: "CaCProj",
+      runbookName: "Provision DB",
+      environmentNames: ["Development"],
+      gitRef: "main",
+    });
+
+    expect(runbookRunCreate).not.toHaveBeenCalled();
+    expect(runbookRunCreateGit).toHaveBeenCalledTimes(1);
+    const [command, gitRef] = runbookRunCreateGit.mock.calls[0];
+    expect(gitRef).toBe("main");
+    expect(command).not.toHaveProperty("Snapshot");
+    expect(command.RunbookName).toBe("Provision DB");
+
+    const body = parseToolResponse<{ success: boolean; gitRef?: string }>(
+      response,
+    );
+    expect(body.success).toBe(true);
+    expect(body.gitRef).toBe("main");
+  });
+
+  it("DB project + gitRef is rejected before either API method is called", async () => {
+    mockProject(dbProject);
+
+    const response = await runRunbookHandler(makeServer(), {
+      spaceName: "Default",
+      projectName: "DbProj",
+      runbookName: "Smoke Test",
+      environmentNames: ["Development"],
+      gitRef: "main",
+    });
+
+    const body = parseToolResponse<{ success: boolean; error: string }>(
+      response,
+    );
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("stores its runbooks in the database");
+    expect(runbookRunCreate).not.toHaveBeenCalled();
+    expect(runbookRunCreateGit).not.toHaveBeenCalled();
+  });
+
+  it("declined elicitation does not issue any run (no create / createGit call)", async () => {
+    mockProject(cacProject);
+
+    const response = await runRunbookHandler(
+      makeServer({ elicitResult: { action: "decline" } }),
+      {
+        spaceName: "Default",
+        projectName: "CaCProj",
+        runbookName: "Provision DB",
+        environmentNames: ["Development"],
+        gitRef: "main",
+      },
+    );
+
+    expect(runbookRunCreate).not.toHaveBeenCalled();
+    expect(runbookRunCreateGit).not.toHaveBeenCalled();
+    assertToolResponse(response);
+    const body = JSON.parse(response.content[0].text);
+    expect(body.success).toBe(false);
+  });
+
+  describe("schema-level rejections", () => {
+    it("rejects gitRef + runbookSnapshotId (the two version-pin mechanisms are mutually exclusive)", () => {
+      const result = runRunbookSchema.safeParse({
+        spaceName: "Default",
+        projectName: "CaCProj",
+        runbookName: "Provision DB",
+        environmentNames: ["Development"],
+        gitRef: "main",
+        runbookSnapshotId: "RunbookSnapshots-1",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.map((i) => i.message).join("\n"),
+        ).toMatch(/runbookSnapshotId cannot be combined with gitRef/);
+      }
+    });
+
+    it("requires environmentNames to be non-empty (existing rule, unchanged)", () => {
+      const result = runRunbookSchema.safeParse({
+        spaceName: "Default",
+        projectName: "Anything",
+        runbookName: "Anything",
+        environmentNames: [],
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/tools/findRunbooks.ts
+++ b/src/tools/findRunbooks.ts
@@ -2,6 +2,9 @@ import {
   Client,
   ProjectRepository,
   RunbookRepository,
+  resolveSpaceId,
+  type Project,
+  type ResourceCollection,
   type Runbook,
 } from "@octopusdeploy/api-client";
 import { z } from "zod";
@@ -10,10 +13,40 @@ import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfi
 import { registerToolDefinition } from "../types/toolConfig.js";
 import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { handleOctopusApiError } from "../helpers/errorHandling.js";
+import { hasRunbooksInGit } from "../helpers/vcsProjectHelpers.js";
 
-function runbookSummary(runbook: Runbook, spaceName: string) {
+function runbookSummary(
+  runbook: Runbook,
+  spaceName: string,
+  cac?: { project: Project; gitRef: string },
+) {
   const encodedSpace = encodeURIComponent(spaceName);
-  const encodedId = encodeURIComponent(runbook.Id);
+
+  if (cac) {
+    const runbookSlug = runbookSlugOf(runbook);
+    const projectSlug = cac.project.Slug;
+    const resourceUri =
+      runbookSlug && projectSlug
+        ? `octopus://spaces/${encodedSpace}/projects/${encodeURIComponent(
+            projectSlug,
+          )}/${encodeURIComponent(cac.gitRef)}/runbooks/${encodeURIComponent(
+            runbookSlug,
+          )}`
+        : undefined;
+
+    return {
+      id: runbook.Id,
+      name: runbook.Name,
+      description: runbook.Description,
+      projectId: runbook.ProjectId,
+      runbookProcessId: runbook.RunbookProcessId,
+      gitRef: cac.gitRef,
+      multiTenancyMode: runbook.MultiTenancyMode,
+      environmentScope: runbook.EnvironmentScope,
+      environments: runbook.Environments,
+      ...(resourceUri ? { resourceUri } : {}),
+    };
+  }
 
   return {
     id: runbook.Id,
@@ -25,11 +58,27 @@ function runbookSummary(runbook: Runbook, spaceName: string) {
     multiTenancyMode: runbook.MultiTenancyMode,
     environmentScope: runbook.EnvironmentScope,
     environments: runbook.Environments,
-    resourceUri: `octopus://spaces/${encodedSpace}/runbooks/${encodedId}`,
+    resourceUri: `octopus://spaces/${encodedSpace}/runbooks/${encodeURIComponent(runbook.Id)}`,
   };
 }
 
-const findRunbooksSchema = z
+// CaC runbooks are addressed by slug. The api-client's Runbook type doesn't
+// declare a Slug field, but the wire response carries one for git-stored
+// runbooks. Fall back to undefined (caller omits resourceUri) rather than
+// fabricating an unfetchable URI.
+function runbookSlugOf(runbook: Runbook): string | undefined {
+  const slug = (runbook as unknown as { Slug?: unknown }).Slug;
+  return typeof slug === "string" && slug.length > 0 ? slug : undefined;
+}
+
+function defaultBranchOf(project: Project): string | undefined {
+  if (project.PersistenceSettings.Type === "VersionControlled") {
+    return project.PersistenceSettings.DefaultBranch;
+  }
+  return undefined;
+}
+
+export const findRunbooksSchema = z
   .object({
     spaceName: z.string().describe("Space name."),
     projectName: z
@@ -41,7 +90,19 @@ const findRunbooksSchema = z
       .string()
       .optional()
       .describe(
-        "Fetch a single runbook by ID. Mutually exclusive with partialName/skip/take.",
+        "Fetch a single DB-backed runbook by ID (e.g. 'Runbooks-123'). Mutually exclusive with partialName/skip/take and with gitRef/runbookSlug.",
+      ),
+    runbookSlug: z
+      .string()
+      .optional()
+      .describe(
+        "Config-as-Code only. Fetch a single CaC runbook by slug at the given gitRef. Requires gitRef.",
+      ),
+    gitRef: z
+      .string()
+      .optional()
+      .describe(
+        "For Config-as-Code projects only. A branch name (e.g. 'main'), tag, or commit SHA. Use get_branches to list available branches.",
       ),
     partialName: z
       .string()
@@ -59,7 +120,228 @@ const findRunbooksSchema = z
         path: ["partialName"],
       });
     }
+    if (args.runbookId && args.gitRef) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "gitRef cannot be combined with runbookId. CaC runbooks have no 'Runbooks-N' ID; use runbookSlug with gitRef instead.",
+        path: ["gitRef"],
+      });
+    }
+    if (args.runbookId && args.runbookSlug) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "runbookSlug and runbookId are mutually exclusive. runbookSlug is for CaC runbooks; runbookId is for DB-backed runbooks.",
+        path: ["runbookSlug"],
+      });
+    }
+    if (args.runbookSlug && !args.gitRef) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "runbookSlug requires gitRef. CaC runbooks are version-pinned by gitRef (branch, tag, or commit).",
+        path: ["runbookSlug"],
+      });
+    }
   });
+
+export type FindRunbooksParams = z.infer<typeof findRunbooksSchema>;
+
+export async function findRunbooksHandler(params: FindRunbooksParams) {
+  const {
+    spaceName,
+    projectName,
+    runbookId,
+    runbookSlug,
+    gitRef,
+    partialName,
+    skip,
+    take,
+  } = params;
+
+  try {
+    const client = await Client.create(getClientConfigurationFromEnvironment());
+    const projectRepository = new ProjectRepository(client, spaceName);
+
+    const projectMatches = await projectRepository.list({
+      partialName: projectName,
+      take: 100,
+    });
+    const project = projectMatches.Items.find((p) => p.Name === projectName);
+    if (!project) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                success: false,
+                error:
+                  `Project '${projectName}' not found in space '${spaceName}'. ` +
+                  `Use list_projects to find valid project names. Project names are case-sensitive.`,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const runbooksInGit = hasRunbooksInGit(project.PersistenceSettings);
+
+    if (runbooksInGit && !gitRef) {
+      const defaultBranch = defaultBranchOf(project);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                success: false,
+                error:
+                  `Project '${projectName}' stores its runbooks in Git. ` +
+                  `Pass gitRef (branch name, tag, or commit SHA).` +
+                  (defaultBranch
+                    ? ` Project default branch: '${defaultBranch}'.`
+                    : "") +
+                  ` Use get_branches to list branches.`,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    if (!runbooksInGit && (gitRef || runbookSlug)) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                success: false,
+                error:
+                  `Project '${projectName}' stores its runbooks in the database; ` +
+                  `gitRef/runbookSlug are not applicable. Use runbookId for a single fetch, or omit it to list.`,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    if (runbooksInGit && gitRef) {
+      const runbookRepository = new RunbookRepository(
+        client,
+        spaceName,
+        project,
+      );
+
+      const lookupKey = runbookSlug ?? runbookId;
+      if (lookupKey) {
+        const runbook = await runbookRepository.getWithGitRef(
+          lookupKey,
+          gitRef,
+        );
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                runbookSummary(runbook, spaceName, { project, gitRef }),
+              ),
+            },
+          ],
+        };
+      }
+
+      const spaceId = await resolveSpaceId(client, spaceName);
+      const listing = await client.get<ResourceCollection<Runbook>>(
+        "~/api/{spaceId}/projects/{projectId}/{gitRef}/runbooks{?skip,take,partialName}",
+        {
+          spaceId,
+          projectId: project.Id,
+          gitRef,
+          ...(skip !== undefined ? { skip } : {}),
+          ...(take !== undefined ? { take } : {}),
+          ...(partialName ? { partialName } : {}),
+        },
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              totalResults: listing.TotalResults,
+              itemsPerPage: listing.ItemsPerPage,
+              numberOfPages: listing.NumberOfPages,
+              lastPageNumber: listing.LastPageNumber,
+              items: listing.Items.map((runbook) =>
+                runbookSummary(runbook, spaceName, { project, gitRef }),
+              ),
+            }),
+          },
+        ],
+      };
+    }
+
+    const runbookRepository = new RunbookRepository(client, spaceName, project);
+
+    if (runbookId) {
+      const runbook = await runbookRepository.get(runbookId);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(runbookSummary(runbook, spaceName)),
+          },
+        ],
+      };
+    }
+
+    const runbooksResponse = await runbookRepository.list({
+      partialName,
+      skip,
+      take,
+    });
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            totalResults: runbooksResponse.TotalResults,
+            itemsPerPage: runbooksResponse.ItemsPerPage,
+            numberOfPages: runbooksResponse.NumberOfPages,
+            lastPageNumber: runbooksResponse.LastPageNumber,
+            items: runbooksResponse.Items.map((runbook) =>
+              runbookSummary(runbook, spaceName),
+            ),
+          }),
+        },
+      ],
+    };
+  } catch (error) {
+    handleOctopusApiError(error, {
+      entityType: "runbook",
+      entityId: runbookId ?? runbookSlug,
+      spaceName,
+      helpText:
+        "Use list_projects to find valid project names. Call find_runbooks without runbookId/runbookSlug to list runbooks. " +
+        "For Config-as-Code projects, pass gitRef (use get_branches to list refs).",
+    });
+  }
+}
 
 export function registerFindRunbooksTool(server: McpServer) {
   server.registerTool(
@@ -68,105 +350,21 @@ export function registerFindRunbooksTool(server: McpServer) {
       title: "Find runbooks in a project",
       description: `Find runbooks in an Octopus Deploy project.
 
-Two modes, picked by which arguments are supplied:
-- runbookId  → fetch the summary for that runbook.
-- neither    → list all runbooks in the project (optionally filtered by partialName).
+Two project kinds are supported:
+- DB-backed projects: address runbooks by 'runbookId' (e.g. 'Runbooks-123'). The summary includes 'publishedRunbookSnapshotId', which run_runbook uses by default.
+- Config-as-Code (CaC) projects: pass 'gitRef' (branch name like 'main', tag, or commit SHA). Address a single runbook by 'runbookSlug'. The summary includes 'gitRef' instead of 'publishedRunbookSnapshotId'; run_runbook needs the same gitRef.
 
-Each summary includes the publishedRunbookSnapshotId (which run_runbook uses by default), the multiTenancyMode, and the environmentScope so callers can determine which environments and tenants are valid targets before invoking run_runbook.`,
+Modes:
+- runbookId             → fetch a single DB runbook.
+- runbookSlug + gitRef  → fetch a single CaC runbook.
+- gitRef alone          → list CaC runbooks at that ref.
+- neither               → list DB runbooks in the project (optionally filtered by partialName).
+
+Each summary includes multiTenancyMode and environmentScope so callers can determine which environments and tenants are valid targets before invoking run_runbook.`,
       inputSchema: findRunbooksSchema,
       annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
-    async ({ spaceName, projectName, runbookId, partialName, skip, take }) => {
-      try {
-        const client = await Client.create(
-          getClientConfigurationFromEnvironment(),
-        );
-        const projectRepository = new ProjectRepository(client, spaceName);
-
-        const projectMatches = await projectRepository.list({
-          partialName: projectName,
-          take: 100,
-        });
-        const project = projectMatches.Items.find(
-          (p) => p.Name === projectName,
-        );
-        if (!project) {
-          // Returned directly (not thrown) so the error surfaces to the LLM
-          // with a project-specific message. handleOctopusApiError below would
-          // otherwise rewrite a thrown "Project not found" into a misleading
-          // "Space not found" because it requires entityId for the entity
-          // branch and falls through to the space branch when entityId is
-          // undefined (we haven't reached the runbook lookup yet).
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(
-                  {
-                    success: false,
-                    error:
-                      `Project '${projectName}' not found in space '${spaceName}'. ` +
-                      `Use list_projects to find valid project names. Project names are case-sensitive.`,
-                  },
-                  null,
-                  2,
-                ),
-              },
-            ],
-            isError: true,
-          };
-        }
-
-        const runbookRepository = new RunbookRepository(
-          client,
-          spaceName,
-          project,
-        );
-
-        if (runbookId) {
-          const runbook = await runbookRepository.get(runbookId);
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(runbookSummary(runbook, spaceName)),
-              },
-            ],
-          };
-        }
-
-        const runbooksResponse = await runbookRepository.list({
-          partialName,
-          skip,
-          take,
-        });
-
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify({
-                totalResults: runbooksResponse.TotalResults,
-                itemsPerPage: runbooksResponse.ItemsPerPage,
-                numberOfPages: runbooksResponse.NumberOfPages,
-                lastPageNumber: runbooksResponse.LastPageNumber,
-                items: runbooksResponse.Items.map((runbook) =>
-                  runbookSummary(runbook, spaceName),
-                ),
-              }),
-            },
-          ],
-        };
-      } catch (error) {
-        handleOctopusApiError(error, {
-          entityType: "runbook",
-          entityId: runbookId,
-          spaceName,
-          helpText:
-            "Use list_projects to find valid project names. Call find_runbooks without runbookId to list all runbooks for a project.",
-        });
-      }
-    },
+    findRunbooksHandler,
   );
 }
 

--- a/src/tools/getVariables.ts
+++ b/src/tools/getVariables.ts
@@ -9,6 +9,7 @@ import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
 import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
+import { hasVariablesInGit } from "../helpers/vcsProjectHelpers.js";
 import type {ResourceCollection} from "@octopusdeploy/api-client/dist/resourceCollection.js";
 
 export function registerGetVariablesTool(server: McpServer) {
@@ -169,26 +170,6 @@ async function loadProjectVariableSet(
     apiClient: Client,
     spaceId: string
 ): Promise<VariableSetResponse | undefined> {
-
-    // This is a bit hacky,  but gets around the limitations of our ts client types without having to define
-    // a heap of new types.
-    // We are expecting the type to match { ConversionState: { VariablesAreInGit: true } }
-    // If the variables are stored in git.
-    function hasVariablesInGit(value: unknown): boolean {
-        if (typeof value !== 'object' || value === null || !('ConversionState' in value)) {
-            return false;
-        }
-
-        const obj = value as Record<string, unknown>;
-        const conversionState = obj.ConversionState;
-
-        return (
-            typeof conversionState === 'object' &&
-            conversionState !== null &&
-            'VariablesAreInGit' in conversionState &&
-            (conversionState as Record<string, unknown>).VariablesAreInGit === true
-        );
-    }
 
     // Check if project has git persistence
     const hasGitVariables = hasVariablesInGit(project.PersistenceSettings);

--- a/src/tools/runRunbook.ts
+++ b/src/tools/runRunbook.ts
@@ -1,4 +1,9 @@
-import { Client, RunbookRunRepository } from "@octopusdeploy/api-client";
+import {
+  Client,
+  ProjectRepository,
+  RunbookRunRepository,
+  type Project,
+} from "@octopusdeploy/api-client";
 import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
@@ -9,213 +14,342 @@ import {
   requireConfirmation,
   unconfirmedResponse,
 } from "../helpers/requireConfirmation.js";
+import { hasRunbooksInGit } from "../helpers/vcsProjectHelpers.js";
+
+export const runRunbookSchema = z
+  .object({
+    spaceName: z.string().describe("The space name"),
+    projectName: z.string().describe("The project name"),
+    runbookName: z
+      .string()
+      .describe("The runbook name (within the project)"),
+    environmentNames: z
+      .array(z.string())
+      .min(1)
+      .describe(
+        "Array of environment names. At least one environment must be provided.",
+      ),
+    tenants: z
+      .array(z.string())
+      .optional()
+      .describe("Array of tenant names for tenanted runs (optional)"),
+    tenantTags: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Array of tenant tags for tenanted runs (e.g., ['Region/US-West', 'Tier/Production'])",
+      ),
+    runbookSnapshotId: z
+      .string()
+      .optional()
+      .describe(
+        "DB-backed runbooks only. Specific snapshot ID. Defaults to the runbook's published snapshot if omitted. Not applicable to Config-as-Code runbooks.",
+      ),
+    gitRef: z
+      .string()
+      .optional()
+      .describe(
+        "Config-as-Code runbooks only. A branch name (e.g. 'main'), tag, or commit SHA. Use get_branches to list available refs. Mutually exclusive with runbookSnapshotId.",
+      ),
+    promptedVariableValues: z
+      .record(z.string())
+      .optional()
+      .describe("Prompted variable values as key-value pairs"),
+    useGuidedFailure: z
+      .boolean()
+      .optional()
+      .describe("Use guided failure mode"),
+    forcePackageDownload: z
+      .boolean()
+      .optional()
+      .describe("Force package download"),
+    specificMachineNames: z
+      .array(z.string())
+      .optional()
+      .describe("Run on specific machines only"),
+    excludedMachineNames: z
+      .array(z.string())
+      .optional()
+      .describe("Exclude specific machines from the run"),
+    skipStepNames: z
+      .array(z.string())
+      .optional()
+      .describe("Skip specific runbook steps"),
+    runAt: z
+      .string()
+      .optional()
+      .describe("Schedule run for later (ISO 8601 date string)"),
+    noRunAfter: z
+      .string()
+      .optional()
+      .describe("Don't run after this time (ISO 8601 date string)"),
+    confirm: z
+      .boolean()
+      .optional()
+      .describe(
+        "Required only when the MCP client does not support elicitation. Set to true to confirm the run; otherwise the tool aborts.",
+      ),
+  })
+  .superRefine((args, ctx) => {
+    if (args.gitRef && args.runbookSnapshotId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "runbookSnapshotId cannot be combined with gitRef. Config-as-Code runbooks are version-pinned by gitRef; DB-backed runbooks by snapshot. Use one or the other.",
+        path: ["runbookSnapshotId"],
+      });
+    }
+  });
+
+export type RunRunbookParams = z.infer<typeof runRunbookSchema>;
+
+function defaultBranchOf(project: Project): string | undefined {
+  if (project.PersistenceSettings.Type === "VersionControlled") {
+    return project.PersistenceSettings.DefaultBranch;
+  }
+  return undefined;
+}
+
+export async function runRunbookHandler(
+  server: McpServer,
+  params: RunRunbookParams,
+) {
+  const {
+    spaceName,
+    projectName,
+    runbookName,
+    environmentNames,
+    tenants,
+    tenantTags,
+    runbookSnapshotId,
+    gitRef,
+    promptedVariableValues,
+    useGuidedFailure,
+    forcePackageDownload,
+    specificMachineNames,
+    excludedMachineNames,
+    skipStepNames,
+    runAt,
+    noRunAfter,
+    confirm,
+  } = params;
+
+  try {
+    const configuration = getClientConfigurationFromEnvironment();
+    const client = await Client.create(configuration);
+
+    const projectRepository = new ProjectRepository(client, spaceName);
+    const projectMatches = await projectRepository.list({
+      partialName: projectName,
+      take: 100,
+    });
+    const project = projectMatches.Items.find((p) => p.Name === projectName);
+    if (!project) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                success: false,
+                error:
+                  `Project '${projectName}' not found in space '${spaceName}'. ` +
+                  `Use list_projects to find valid project names.`,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const runbooksInGit = hasRunbooksInGit(project.PersistenceSettings);
+
+    if (runbooksInGit && !gitRef) {
+      const defaultBranch = defaultBranchOf(project);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                success: false,
+                error:
+                  `Project '${projectName}' stores its runbooks in Git. ` +
+                  `Pass gitRef (branch name, tag, or commit SHA).` +
+                  (defaultBranch
+                    ? ` Project default branch: '${defaultBranch}'.`
+                    : "") +
+                  ` Use get_branches to list refs.`,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    if (!runbooksInGit && gitRef) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                success: false,
+                error:
+                  `Project '${projectName}' stores its runbooks in the database; ` +
+                  `gitRef is not applicable. Omit gitRef, or use runbookSnapshotId to pick a specific snapshot.`,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const isTenanted =
+      (tenants && tenants.length > 0) ||
+      (tenantTags && tenantTags.length > 0);
+
+    const tenantSummary = isTenanted
+      ? ` for tenants [${(tenants ?? []).join(", ")}${
+          tenantTags?.length ? `; tags: ${tenantTags.join(", ")}` : ""
+        }]`
+      : "";
+    const gitRefSuffix = runbooksInGit ? ` (gitRef: ${gitRef})` : "";
+    const confirmMessage =
+      `Run runbook ${runbookName} of ${projectName} in ` +
+      `[${environmentNames.join(", ")}]${tenantSummary} in space ${spaceName}${gitRefSuffix}?`;
+
+    const baseCommand = {
+      spaceName: spaceName,
+      ProjectName: projectName,
+      RunbookName: runbookName,
+      EnvironmentNames: environmentNames,
+      ...(tenants && { Tenants: tenants }),
+      ...(tenantTags && { TenantTags: tenantTags }),
+      ...(promptedVariableValues && { Variables: promptedVariableValues }),
+      ...(useGuidedFailure !== undefined && {
+        UseGuidedFailure: useGuidedFailure,
+      }),
+      ...(forcePackageDownload !== undefined && {
+        ForcePackageDownload: forcePackageDownload,
+      }),
+      ...(specificMachineNames && {
+        SpecificMachineNames: specificMachineNames,
+      }),
+      ...(excludedMachineNames && {
+        ExcludedMachineNames: excludedMachineNames,
+      }),
+      ...(skipStepNames && { SkipStepNames: skipStepNames }),
+      ...(runAt && { RunAt: new Date(runAt) }),
+      ...(noRunAfter && { NoRunAfter: new Date(noRunAfter) }),
+    };
+
+    // DB command may also carry Snapshot. Zod has already rejected
+    // Snapshot+gitRef, so this branch only ever fires for DB runbooks.
+    const dbCommand = {
+      ...baseCommand,
+      ...(runbookSnapshotId && { Snapshot: runbookSnapshotId }),
+    };
+
+    const commandForConfirm = runbooksInGit ? baseCommand : dbCommand;
+
+    const confirmation = await requireConfirmation(server, {
+      message: confirmMessage,
+      fallbackConfirm: confirm,
+      change: { source: {}, target: commandForConfirm },
+    });
+    if (!confirmation.confirmed) {
+      return unconfirmedResponse(confirmation, { action: "runbook run" });
+    }
+
+    const runbookRunRepository = new RunbookRunRepository(client, spaceName);
+
+    const response =
+      runbooksInGit && gitRef
+        ? await runbookRunRepository.createGit(baseCommand, gitRef)
+        : await runbookRunRepository.create(dbCommand);
+
+    const tasks = response.RunbookRunServerTasks || [];
+    const encodedSpace = encodeURIComponent(spaceName);
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              success: true,
+              runsCreated: tasks.length,
+              ...(runbooksInGit ? { gitRef } : {}),
+              runbookRunTasks: tasks.map((task) => ({
+                taskId: task.ServerTaskId,
+                runbookRunId: task.RunbookRunId,
+                resourceUri: `octopus://spaces/${encodedSpace}/tasks/${encodeURIComponent(task.ServerTaskId)}`,
+              })),
+              message: `Successfully started ${tasks.length} runbook run(s) for ${runbookName}`,
+              helpText: `Fetch octopus://spaces/{spaceName}/tasks/{taskId} (or /details for the structured activity tree) via resources/read or read_resource to monitor run progress. To search the raw log for a specific error or step, call grep_task_log with the taskId.`,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  } catch (error) {
+    if (error instanceof Error && !error.message.includes("octopus")) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                success: false,
+                error: error.message,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    handleOctopusApiError(error, {
+      entityType: "runbook run",
+      spaceName,
+      helpText:
+        "Use list_projects to find valid project names, list_environments for environment names, find_tenants for tenant information. " +
+        "For DB runbooks ensure the runbook has a published snapshot (or pass runbookSnapshotId); for Config-as-Code runbooks pass gitRef (use get_branches).",
+    });
+  }
+}
 
 export function registerRunRunbookTool(server: McpServer) {
   server.registerTool(
     "run_runbook",
     {
       title: "Run a runbook in Octopus Deploy",
-      description: `Run a runbook against one or more environments in Octopus Deploy
+      description: `Run a runbook against one or more environments in Octopus Deploy.
 
-Runbooks execute operational processes (DB backups, smoke tests, environment refresh, etc.) against the specified environments. By default the published snapshot is used; pass runbookSnapshotId to run a specific snapshot. For tenanted runs, supply tenants and/or tenantTags.`,
-      inputSchema: {
-        spaceName: z.string().describe("The space name"),
-        projectName: z.string().describe("The project name"),
-        runbookName: z
-          .string()
-          .describe("The runbook name (within the project)"),
-        environmentNames: z
-          .array(z.string())
-          .min(1)
-          .describe(
-            "Array of environment names. At least one environment must be provided.",
-          ),
-        tenants: z
-          .array(z.string())
-          .optional()
-          .describe("Array of tenant names for tenanted runs (optional)"),
-        tenantTags: z
-          .array(z.string())
-          .optional()
-          .describe(
-            "Array of tenant tags for tenanted runs (e.g., ['Region/US-West', 'Tier/Production'])",
-          ),
-        runbookSnapshotId: z
-          .string()
-          .optional()
-          .describe(
-            "Specific snapshot ID. Defaults to the runbook's published snapshot if omitted.",
-          ),
-        promptedVariableValues: z
-          .record(z.string())
-          .optional()
-          .describe("Prompted variable values as key-value pairs"),
-        useGuidedFailure: z
-          .boolean()
-          .optional()
-          .describe("Use guided failure mode"),
-        forcePackageDownload: z
-          .boolean()
-          .optional()
-          .describe("Force package download"),
-        specificMachineNames: z
-          .array(z.string())
-          .optional()
-          .describe("Run on specific machines only"),
-        excludedMachineNames: z
-          .array(z.string())
-          .optional()
-          .describe("Exclude specific machines from the run"),
-        skipStepNames: z
-          .array(z.string())
-          .optional()
-          .describe("Skip specific runbook steps"),
-        runAt: z
-          .string()
-          .optional()
-          .describe("Schedule run for later (ISO 8601 date string)"),
-        noRunAfter: z
-          .string()
-          .optional()
-          .describe("Don't run after this time (ISO 8601 date string)"),
-        confirm: z
-          .boolean()
-          .optional()
-          .describe(
-            "Required only when the MCP client does not support elicitation. Set to true to confirm the run; otherwise the tool aborts.",
-          ),
-      },
+Runbooks execute operational processes (DB backups, smoke tests, environment refresh, etc.) against the specified environments. For tenanted runs, supply tenants and/or tenantTags.
+
+Two project kinds:
+- DB-backed projects: by default the runbook's published snapshot is used; pass runbookSnapshotId to pick a specific snapshot.
+- Config-as-Code projects: pass gitRef (branch name like 'main', tag, or commit SHA). Snapshots don't apply — the gitRef is the version pin. Use find_runbooks with the same gitRef to discover runbook names.`,
+      inputSchema: runRunbookSchema,
       annotations: DESTRUCTIVE_WRITE_TOOL_ANNOTATIONS,
     },
-    async ({
-      spaceName,
-      projectName,
-      runbookName,
-      environmentNames,
-      tenants,
-      tenantTags,
-      runbookSnapshotId,
-      promptedVariableValues,
-      useGuidedFailure,
-      forcePackageDownload,
-      specificMachineNames,
-      excludedMachineNames,
-      skipStepNames,
-      runAt,
-      noRunAfter,
-      confirm,
-    }) => {
-      try {
-        const isTenanted =
-          (tenants && tenants.length > 0) ||
-          (tenantTags && tenantTags.length > 0);
-
-        const tenantSummary = isTenanted
-          ? ` for tenants [${(tenants ?? []).join(", ")}${
-              tenantTags?.length ? `; tags: ${tenantTags.join(", ")}` : ""
-            }]`
-          : "";
-        const confirmMessage =
-          `Run runbook ${runbookName} of ${projectName} in ` +
-          `[${environmentNames.join(", ")}]${tenantSummary} in space ${spaceName}?`;
-
-        const command = {
-          spaceName: spaceName,
-          ProjectName: projectName,
-          RunbookName: runbookName,
-          EnvironmentNames: environmentNames,
-          ...(tenants && { Tenants: tenants }),
-          ...(tenantTags && { TenantTags: tenantTags }),
-          ...(runbookSnapshotId && { Snapshot: runbookSnapshotId }),
-          ...(promptedVariableValues && { Variables: promptedVariableValues }),
-          ...(useGuidedFailure !== undefined && {
-            UseGuidedFailure: useGuidedFailure,
-          }),
-          ...(forcePackageDownload !== undefined && {
-            ForcePackageDownload: forcePackageDownload,
-          }),
-          ...(specificMachineNames && {
-            SpecificMachineNames: specificMachineNames,
-          }),
-          ...(excludedMachineNames && {
-            ExcludedMachineNames: excludedMachineNames,
-          }),
-          ...(skipStepNames && { SkipStepNames: skipStepNames }),
-          ...(runAt && { RunAt: new Date(runAt) }),
-          ...(noRunAfter && { NoRunAfter: new Date(noRunAfter) }),
-        };
-
-        const confirmation = await requireConfirmation(server, {
-          message: confirmMessage,
-          fallbackConfirm: confirm,
-          change: { source: {}, target: command },
-        });
-        if (!confirmation.confirmed) {
-          return unconfirmedResponse(confirmation, { action: "runbook run" });
-        }
-
-        const configuration = getClientConfigurationFromEnvironment();
-        const client = await Client.create(configuration);
-        const runbookRunRepository = new RunbookRunRepository(
-          client,
-          spaceName,
-        );
-
-        const response = await runbookRunRepository.create(command);
-
-        const tasks = response.RunbookRunServerTasks || [];
-        const encodedSpace = encodeURIComponent(spaceName);
-
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(
-                {
-                  success: true,
-                  runsCreated: tasks.length,
-                  runbookRunTasks: tasks.map((task) => ({
-                    taskId: task.ServerTaskId,
-                    runbookRunId: task.RunbookRunId,
-                    resourceUri: `octopus://spaces/${encodedSpace}/tasks/${encodeURIComponent(task.ServerTaskId)}`,
-                  })),
-                  message: `Successfully started ${tasks.length} runbook run(s) for ${runbookName}`,
-                  helpText: `Fetch octopus://spaces/{spaceName}/tasks/{taskId} (or /details for the structured activity tree) via resources/read or read_resource to monitor run progress. To search the raw log for a specific error or step, call grep_task_log with the taskId.`,
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-        };
-      } catch (error) {
-        if (error instanceof Error && !error.message.includes("octopus")) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(
-                  {
-                    success: false,
-                    error: error.message,
-                  },
-                  null,
-                  2,
-                ),
-              },
-            ],
-            isError: true,
-          };
-        }
-
-        handleOctopusApiError(error, {
-          entityType: "runbook run",
-          spaceName,
-          helpText:
-            "Use list_projects to find valid project names, list_environments for environment names, find_tenants for tenant information. Ensure the runbook has a published snapshot (or pass an explicit runbookSnapshotId) and you have permissions to run it.",
-        });
-      }
-    },
+    (params) => runRunbookHandler(server, params),
   );
 }
 
@@ -223,8 +357,8 @@ registerToolDefinition({
   toolName: "run_runbook",
   config: { toolset: "runbooks", readOnly: false },
   registerFn: registerRunRunbookTool,
-  // The api-client's RunbookRunRepository.create throws at runtime if the
-  // server is older than 2022.3.5512 (the Executions API minimum). Surface
+  // The api-client's RunbookRunRepository.create/createGit throw at runtime if
+  // the server is older than 2022.3.5512 (the Executions API minimum). Surface
   // that here so --list-tools-by-version reports it accurately.
   minimumOctopusVersion: "2022.3.5512",
 });


### PR DESCRIPTION
## Summary

`find_runbooks` and `run_runbook` previously failed against Config-as-Code (CaC) projects — the Octopus server rejected DB-only routes with *"version-controlled resource on a non-version control route"*. This PR wires up the git-aware api-client methods that were already available but unused, plus adds a CaC variant for the runbook resource URI so `read_resource` works end-to-end.

- **`find_runbooks`** — adds `gitRef` (branch, tag, or commit SHA) and CaC-only `runbookSlug`. Single-fetch uses `RunbookRepository.getWithGitRef`; listing calls `~/api/{spaceId}/projects/{projectId}/{gitRef}/runbooks` directly (api-client has no `listWithGitRef`). CaC summaries echo `gitRef` and omit `publishedRunbookSnapshotId`.
- **`run_runbook`** — adds `gitRef`. CaC branch calls `RunbookRunRepository.createGit`. Project lookup lifted above `requireConfirmation` so the confirm prompt shows `(gitRef: ...)`.
- **`runbook` resource** — adds a second descriptor `octopus://spaces/{spaceName}/projects/{projectSlug}/{gitRef}/runbooks/{runbookSlug}` alongside the existing DB form.
- **Helpers** — adds `hasRunbooksInGit` and `hasVariablesInGit` to `vcsProjectHelpers.ts` (names mirror the C# `HasRunbooksInGit` extension in the server repo). Refactors `getVariables.ts` to use the shared helper.

CaC detection uses `PersistenceSettings.ConversionState.RunbooksAreInGit` specifically — not `IsVersionControlled` — because a project can be CaC for its deployment process while keeping runbooks in the database during migration.

Zod `superRefine` enforces mutually-exclusive arg combinations at validation time so wrong-shape calls fail early with a clear schema error:
- `gitRef` ⊕ `runbookSnapshotId` (the two version-pin mechanisms)
- `runbookId` ⊕ `gitRef` / `runbookSlug` (DB ID belongs to DB projects; gitRef/slug belong to CaC)
- `runbookSlug` requires `gitRef` (CaC slugs aren't unique without a ref)

## Test plan

Unit coverage (mocked api-client):
- [x] DB project listing → legacy shape with `publishedRunbookSnapshotId` and DB `resourceUri`
- [x] DB project + `runbookId` → legacy single-fetch shape
- [x] CaC project without `gitRef` → error mentions `DefaultBranch` and `get_branches`, no API call
- [x] CaC + `gitRef` listing → hits git URL, returns CaC summaries (with `gitRef`, no `publishedRunbookSnapshotId`, CaC `resourceUri`)
- [x] CaC + `gitRef` + `runbookSlug` → `getWithGitRef(slug, gitRef)` called
- [x] CaC response without `Slug` field → falls back to omitting `resourceUri` rather than fabricating one
- [x] DB + `gitRef` → rejected before any API call
- [x] `run_runbook` DB no `gitRef`/`runbookSnapshotId` → `create()` called with no `Snapshot`
- [x] `run_runbook` DB + `runbookSnapshotId` → `Snapshot` passed through
- [x] `run_runbook` CaC + `gitRef` → `createGit(command, gitRef)` called, command has no `Snapshot`, response echoes `gitRef`
- [x] `run_runbook` declined elicitation → no create/createGit call
- [x] All four `superRefine` rules reject at schema validation
- [x] `dispatch.test.ts` — DB and CaC runbook URI templates dispatch without cross-talk

Integration verification (against a live Octopus instance — needs a CaC project with `RunbooksAreInGit = true` and runbooks on at least two branches):
- [ ] `find_runbooks` DB, no `gitRef` → items with `publishedRunbookSnapshotId`; dereference DB `resourceUri` works
- [ ] `find_runbooks` CaC, no `gitRef` → error mentions `get_branches`
- [ ] `find_runbooks` CaC + `gitRef: main` → items with `gitRef` and CaC `resourceUri`; dereference works
- [ ] `find_runbooks` CaC + feature-branch `gitRef` → items reflect the feature branch (verify divergent property)
- [ ] `run_runbook` DB → succeeds; confirm prompt does NOT mention `gitRef`
- [ ] `run_runbook` CaC + `gitRef: main` → succeeds; confirm prompt shows `(gitRef: main)`
- [ ] `read_resource` with a CaC `resourceUri` → returns the right body
- [ ] **Verify CaC response carries a `Slug` field** — if it does, the CaC `resourceUri` will be emitted; if not, the code falls back to omitting it (test #6 above covers this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)