### PR TITLE
fix: stop array/boolean/number args collapsing on tools using superRefine

### DIFF
--- a/src/helpers/zodErrorResponse.ts
+++ b/src/helpers/zodErrorResponse.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+/**
+ * Wrap a Zod parse error in the structured tool-response shape used across
+ * tools whose published inputSchema is a plain `z.object(...)` (so the MCP SDK
+ * can read `.shape`) and whose cross-field invariants live on a separate
+ * `.superRefine(...)` schema, evaluated inside the handler.
+ *
+ * See the SDK-workaround comment on the find_events / run_runbook input
+ * schemas for the underlying reason this split exists.
+ */
+export function zodErrorResponse(error: z.ZodError) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            success: false,
+            error: "Invalid argument combination",
+            issues: error.issues.map((i) => ({
+              path: i.path,
+              message: i.message,
+            })),
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+    isError: true as const,
+  };
+}

--- a/src/tools/__tests__/findRunbooks.handler.test.ts
+++ b/src/tools/__tests__/findRunbooks.handler.test.ts
@@ -38,7 +38,7 @@ vi.mock("@octopusdeploy/api-client", async (importOriginal) => {
 
 import {
   findRunbooksHandler,
-  findRunbooksSchema,
+  findRunbooksValidationSchema,
 } from "../findRunbooks.js";
 import { parseToolResponse } from "./testSetup.js";
 
@@ -281,7 +281,7 @@ describe("findRunbooksHandler", () => {
 
   describe("schema-level rejections", () => {
     it("rejects runbookId + gitRef (a runbook ID belongs to a DB project; gitRef belongs to a CaC project)", () => {
-      const result = findRunbooksSchema.safeParse({
+      const result = findRunbooksValidationSchema.safeParse({
         spaceName: "Default",
         projectName: "Anything",
         runbookId: "Runbooks-1",
@@ -296,7 +296,7 @@ describe("findRunbooksHandler", () => {
     });
 
     it("rejects runbookSlug without gitRef (CaC slugs aren't unique without a ref)", () => {
-      const result = findRunbooksSchema.safeParse({
+      const result = findRunbooksValidationSchema.safeParse({
         spaceName: "Default",
         projectName: "Anything",
         runbookSlug: "provision-db",
@@ -310,7 +310,7 @@ describe("findRunbooksHandler", () => {
     });
 
     it("rejects runbookId + runbookSlug (the two ID forms are mutually exclusive)", () => {
-      const result = findRunbooksSchema.safeParse({
+      const result = findRunbooksValidationSchema.safeParse({
         spaceName: "Default",
         projectName: "Anything",
         runbookId: "Runbooks-1",
@@ -326,7 +326,7 @@ describe("findRunbooksHandler", () => {
     });
 
     it("still rejects runbookId + partialName (existing rule, unchanged)", () => {
-      const result = findRunbooksSchema.safeParse({
+      const result = findRunbooksValidationSchema.safeParse({
         spaceName: "Default",
         projectName: "Anything",
         runbookId: "Runbooks-1",

--- a/src/tools/__tests__/runRunbook.handler.test.ts
+++ b/src/tools/__tests__/runRunbook.handler.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { z } from "zod";
 
 const projectList = vi.fn();
 const runbookRunCreate = vi.fn();
@@ -32,7 +33,11 @@ vi.mock("@octopusdeploy/api-client", async (importOriginal) => {
 });
 
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { runRunbookHandler, runRunbookSchema } from "../runRunbook.js";
+import {
+  runRunbookHandler,
+  runRunbookInputSchema,
+  runRunbookValidationSchema,
+} from "../runRunbook.js";
 import { assertToolResponse, parseToolResponse } from "./testSetup.js";
 
 function makeServer(opts: {
@@ -216,7 +221,7 @@ describe("runRunbookHandler", () => {
 
   describe("schema-level rejections", () => {
     it("rejects gitRef + runbookSnapshotId (the two version-pin mechanisms are mutually exclusive)", () => {
-      const result = runRunbookSchema.safeParse({
+      const result = runRunbookValidationSchema.safeParse({
         spaceName: "Default",
         projectName: "CaCProj",
         runbookName: "Provision DB",
@@ -233,13 +238,71 @@ describe("runRunbookHandler", () => {
     });
 
     it("requires environmentNames to be non-empty (existing rule, unchanged)", () => {
-      const result = runRunbookSchema.safeParse({
+      const result = runRunbookValidationSchema.safeParse({
         spaceName: "Default",
         projectName: "Anything",
         runbookName: "Anything",
         environmentNames: [],
       });
       expect(result.success).toBe(false);
+    });
+
+    it("accepts environmentNames as a real array (regression: bug where the published schema collapsed and arrays arrived stringified)", () => {
+      const result = runRunbookValidationSchema.safeParse({
+        spaceName: "Default",
+        projectName: "Feedz.io",
+        runbookName: "Run E2E Tests",
+        gitRef: "dc073e56b32e9d01c3c5de70bc3ba80e1de87855",
+        environmentNames: ["Test"],
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // The MCP SDK at 1.29 publishes the inputSchema by reading `.shape` off the
+  // passed Zod schema. If `runRunbookInputSchema` regresses to a refined
+  // ZodEffects wrapper (e.g. someone re-applies `.superRefine` directly to the
+  // exported schema once the upstream fix lands prematurely), `.shape` will go
+  // away and clients will see an empty schema — arrays/booleans/numbers will
+  // be stringified by clients. These tests guard against that regression.
+  describe("published inputSchema shape (SDK workaround guard)", () => {
+    it("exposes a Zod object .shape directly (no ZodEffects wrapper)", () => {
+      expect(runRunbookInputSchema).toBeInstanceOf(z.ZodObject);
+      expect(runRunbookInputSchema.shape).toBeDefined();
+    });
+
+    it("declares the array-typed fields the LLM otherwise stringifies", () => {
+      const shape = runRunbookInputSchema.shape;
+
+      // environmentNames is required (no .optional()), so it's a ZodArray directly.
+      expect(shape.environmentNames).toBeInstanceOf(z.ZodArray);
+
+      for (const arrayField of [
+        "tenants",
+        "tenantTags",
+        "specificMachineNames",
+        "excludedMachineNames",
+        "skipStepNames",
+      ]) {
+        const field = shape[arrayField as keyof typeof shape];
+        expect(field, `missing field: ${arrayField}`).toBeInstanceOf(
+          z.ZodOptional,
+        );
+        const inner = (field as z.ZodOptional<z.ZodArray<z.ZodString>>)._def
+          .innerType;
+        expect(inner, `${arrayField} inner type`).toBeInstanceOf(z.ZodArray);
+      }
+    });
+
+    it("useGuidedFailure and forcePackageDownload are typed as booleans (not strings)", () => {
+      const shape = runRunbookInputSchema.shape;
+      const guided = (shape.useGuidedFailure as z.ZodOptional<z.ZodBoolean>)
+        ._def.innerType;
+      const force = (
+        shape.forcePackageDownload as z.ZodOptional<z.ZodBoolean>
+      )._def.innerType;
+      expect(guided).toBeInstanceOf(z.ZodBoolean);
+      expect(force).toBeInstanceOf(z.ZodBoolean);
     });
   });
 });

--- a/src/tools/__tests__/updateFeatureToggle.handler.test.ts
+++ b/src/tools/__tests__/updateFeatureToggle.handler.test.ts
@@ -24,7 +24,7 @@ vi.mock("@octopusdeploy/api-client", async (importOriginal) => {
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   updateFeatureToggleHandler,
-  updateFeatureToggleSchema,
+  updateFeatureToggleValidationSchema,
 } from "../updateFeatureToggle.js";
 import { assertToolResponse } from "./testSetup.js";
 import { type FeatureToggleResource } from "../../types/featureToggleTypes.js";
@@ -156,7 +156,7 @@ describe("updateFeatureToggleHandler", () => {
     // patch while the confirmation diff overwrote earlier entries with later
     // ones — the user could approve one change and a different one would go
     // through. Catch it before it reaches the handler.
-    const result = updateFeatureToggleSchema.safeParse({
+    const result = updateFeatureToggleValidationSchema.safeParse({
       spaceName: "Default",
       projectId: "Projects-123",
       slug: "checkout-redesign",

--- a/src/tools/findEvents.ts
+++ b/src/tools/findEvents.ts
@@ -9,6 +9,7 @@ import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfi
 import { registerToolDefinition } from "../types/toolConfig.js";
 import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { stripLinks } from "../helpers/stripLinks.js";
+import { zodErrorResponse } from "../helpers/zodErrorResponse.js";
 import {
   validateEntityId,
   handleOctopusApiError,
@@ -333,33 +334,6 @@ export const findEventsValidationSchema = findEventsInputSchema.superRefine(
 
 /** Resolved (post-validation) argument type for the handler. */
 export type FindEventsParams = z.infer<typeof findEventsValidationSchema>;
-
-/**
- * Wrap a Zod parse error in the structured tool-response shape used elsewhere
- * for argument-validation failures.
- */
-function zodErrorResponse(error: z.ZodError) {
-  return {
-    content: [
-      {
-        type: "text" as const,
-        text: JSON.stringify(
-          {
-            success: false,
-            error: "Invalid argument combination",
-            issues: error.issues.map((i) => ({
-              path: i.path,
-              message: i.message,
-            })),
-          },
-          null,
-          2,
-        ),
-      },
-    ],
-    isError: true as const,
-  };
-}
 
 function eventSummary(event: EventResource, excludeDifference?: boolean) {
   const stripped = stripLinks(event) as Record<string, unknown>;

--- a/src/tools/findInterruptions.ts
+++ b/src/tools/findInterruptions.ts
@@ -9,6 +9,7 @@ import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfi
 import { registerToolDefinition } from "../types/toolConfig.js";
 import { getPublicUrl } from "../helpers/getPublicUrl.js";
 import { getCurrentUserCached } from "../helpers/userCache.js";
+import { zodErrorResponse } from "../helpers/zodErrorResponse.js";
 import {
   validateEntityId,
   handleOctopusApiError,
@@ -91,44 +92,50 @@ export interface FindInterruptionsParams {
   take?: number;
 }
 
-const findInterruptionsSchema = z
-  .object({
-    spaceName: z.string().describe("Space name."),
-    interruptionId: z
-      .string()
-      .optional()
-      .describe(
-        "Fetch the slim summary for a single interruption by ID (e.g. Interruptions-1). " +
-          "Mutually exclusive with regarding/assignedToMe/pendingOnly. " +
-          "For the full body (form definition, instructions, button options, submitted values) dereference the returned resourceUri.",
-      ),
-    pendingOnly: z
-      .boolean()
-      .optional()
-      .default(true)
-      .describe("Return only unprocessed (pending) interruptions. Defaults to true. Ignored when interruptionId is set."),
-    assignedToMe: z
-      .boolean()
-      .optional()
-      .describe(
-        "Limit to interruptions the authenticated user can act on (CanTakeResponsibility or HasResponsibility, " +
-          "or where the user is the explicit ResponsibleUserId). When true, /users/me is resolved (cached per session). " +
-          "Octopus has no responsibleUserId query parameter, so the tool pages through the server result set and " +
-          "post-filters; pages are scanned up to a safety cap (filteredAs.scanComplete signals whether the entire " +
-          "result set was inspected). totalResults reflects the post-filter count; the unfiltered server total is " +
-          "exposed under filteredAs. Ignored when interruptionId is set.",
-      ),
-    regarding: z
-      .string()
-      .optional()
-      .describe(
-        "Native server-side filter to interruptions related to a specific entity ID " +
-          "(e.g. ServerTasks-1234, Deployments-5678). Ignored when interruptionId is set.",
-      ),
-    skip: z.number().optional().describe("Pagination offset. Ignored when interruptionId is set."),
-    take: z.number().optional().describe("Pagination page size. Ignored when interruptionId is set."),
-  })
-  .superRefine((args, ctx) => {
+// SDK workaround: publish a plain `z.object(...)` as `inputSchema`; refinements
+// live on `findInterruptionsValidationSchema` and run inside the handler. See
+// the comment on run_runbook / find_events for the underlying reason.
+const findInterruptionsRawShape = {
+  spaceName: z.string().describe("Space name."),
+  interruptionId: z
+    .string()
+    .optional()
+    .describe(
+      "Fetch the slim summary for a single interruption by ID (e.g. Interruptions-1). " +
+        "Mutually exclusive with regarding/assignedToMe/pendingOnly. " +
+        "For the full body (form definition, instructions, button options, submitted values) dereference the returned resourceUri.",
+    ),
+  pendingOnly: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe("Return only unprocessed (pending) interruptions. Defaults to true. Ignored when interruptionId is set."),
+  assignedToMe: z
+    .boolean()
+    .optional()
+    .describe(
+      "Limit to interruptions the authenticated user can act on (CanTakeResponsibility or HasResponsibility, " +
+        "or where the user is the explicit ResponsibleUserId). When true, /users/me is resolved (cached per session). " +
+        "Octopus has no responsibleUserId query parameter, so the tool pages through the server result set and " +
+        "post-filters; pages are scanned up to a safety cap (filteredAs.scanComplete signals whether the entire " +
+        "result set was inspected). totalResults reflects the post-filter count; the unfiltered server total is " +
+        "exposed under filteredAs. Ignored when interruptionId is set.",
+    ),
+  regarding: z
+    .string()
+    .optional()
+    .describe(
+      "Native server-side filter to interruptions related to a specific entity ID " +
+        "(e.g. ServerTasks-1234, Deployments-5678). Ignored when interruptionId is set.",
+    ),
+  skip: z.number().optional().describe("Pagination offset. Ignored when interruptionId is set."),
+  take: z.number().optional().describe("Pagination page size. Ignored when interruptionId is set."),
+};
+
+export const findInterruptionsInputSchema = z.object(findInterruptionsRawShape);
+
+export const findInterruptionsValidationSchema =
+  findInterruptionsInputSchema.superRefine((args, ctx) => {
     if (!args.interruptionId) return;
     const conflicting: Array<keyof typeof args> = [
       "regarding",
@@ -381,10 +388,14 @@ Each summary includes:
 - taskResourceUri  → octopus://spaces/{spaceName}/tasks/{taskId} for the surrounding deployment/runbook task.
 - publicUrl        → Octopus portal deep link to take action.
 - formElementNames → just the field names (e.g. Instructions, Notes, Result). Field values are NOT in the slim summary; fetch resourceUri for those.`,
-      inputSchema: findInterruptionsSchema,
+      inputSchema: findInterruptionsInputSchema,
       annotations: { readOnlyHint: true },
     },
-    findInterruptionsHandler,
+    async (args) => {
+      const parsed = findInterruptionsValidationSchema.safeParse(args);
+      if (!parsed.success) return zodErrorResponse(parsed.error);
+      return findInterruptionsHandler(parsed.data);
+    },
   );
 }
 

--- a/src/tools/findReleases.ts
+++ b/src/tools/findReleases.ts
@@ -4,6 +4,7 @@ import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getClientConfigurationFromEnvironment } from "../helpers/getClientConfigurationFromEnvironment.js";
 import { registerToolDefinition } from "../types/toolConfig.js";
 import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
+import { zodErrorResponse } from "../helpers/zodErrorResponse.js";
 import {
   validateEntityId,
   handleOctopusApiError,
@@ -36,27 +37,33 @@ function releaseSummary(release: Release, spaceName: string) {
   };
 }
 
-const findReleasesSchema = z
-  .object({
-    spaceName: z.string().describe("Space name."),
-    releaseId: z
-      .string()
-      .optional()
-      .describe(
-        "Fetch a single release by ID. Mutually exclusive with projectId and searchByVersion.",
-      ),
-    projectId: z
-      .string()
-      .optional()
-      .describe("Restrict listing to a single project. Mutually exclusive with releaseId."),
-    searchByVersion: z
-      .string()
-      .optional()
-      .describe("Filter by version string. Requires projectId."),
-    skip: z.number().optional().describe("Pagination offset."),
-    take: z.number().optional().describe("Pagination page size."),
-  })
-  .superRefine((args, ctx) => {
+// SDK workaround: publish a plain `z.object(...)` as `inputSchema`; refinements
+// live on `findReleasesValidationSchema` and run inside the handler. See the
+// comment on run_runbook / find_events for the underlying reason.
+const findReleasesRawShape = {
+  spaceName: z.string().describe("Space name."),
+  releaseId: z
+    .string()
+    .optional()
+    .describe(
+      "Fetch a single release by ID. Mutually exclusive with projectId and searchByVersion.",
+    ),
+  projectId: z
+    .string()
+    .optional()
+    .describe("Restrict listing to a single project. Mutually exclusive with releaseId."),
+  searchByVersion: z
+    .string()
+    .optional()
+    .describe("Filter by version string. Requires projectId."),
+  skip: z.number().optional().describe("Pagination offset."),
+  take: z.number().optional().describe("Pagination page size."),
+};
+
+export const findReleasesInputSchema = z.object(findReleasesRawShape);
+
+export const findReleasesValidationSchema = findReleasesInputSchema.superRefine(
+  (args, ctx) => {
     if (args.releaseId && args.projectId) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -80,7 +87,8 @@ const findReleasesSchema = z
         path: ["searchByVersion"],
       });
     }
-  });
+  },
+);
 
 export function registerFindReleasesTool(server: McpServer) {
   server.registerTool(
@@ -96,10 +104,14 @@ export function registerFindReleasesTool(server: McpServer) {
 
   Each summary includes a resourceUri for fetching the full release body
   (release notes, packages, build information, custom fields).`,
-      inputSchema: findReleasesSchema,
+      inputSchema: findReleasesInputSchema,
       annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
-    async ({ spaceName, releaseId, projectId, searchByVersion, skip, take }) => {
+    async (args) => {
+      const parsed = findReleasesValidationSchema.safeParse(args);
+      if (!parsed.success) return zodErrorResponse(parsed.error);
+      const { spaceName, releaseId, projectId, searchByVersion, skip, take } =
+        parsed.data;
       const client = await Client.create(getClientConfigurationFromEnvironment());
       const releaseRepository = new ReleaseRepository(client, spaceName);
 

--- a/src/tools/findRunbooks.ts
+++ b/src/tools/findRunbooks.ts
@@ -14,6 +14,7 @@ import { registerToolDefinition } from "../types/toolConfig.js";
 import { READ_ONLY_TOOL_ANNOTATIONS } from "../types/toolAnnotations.js";
 import { handleOctopusApiError } from "../helpers/errorHandling.js";
 import { hasRunbooksInGit } from "../helpers/vcsProjectHelpers.js";
+import { zodErrorResponse } from "../helpers/zodErrorResponse.js";
 
 function runbookSummary(
   runbook: Runbook,
@@ -78,40 +79,46 @@ function defaultBranchOf(project: Project): string | undefined {
   return undefined;
 }
 
-export const findRunbooksSchema = z
-  .object({
-    spaceName: z.string().describe("Space name."),
-    projectName: z
-      .string()
-      .describe(
-        "Project name. Runbooks are scoped to a project, so this is required for both single fetch and listing.",
-      ),
-    runbookId: z
-      .string()
-      .optional()
-      .describe(
-        "Fetch a single DB-backed runbook by ID (e.g. 'Runbooks-123'). Mutually exclusive with partialName/skip/take and with gitRef/runbookSlug.",
-      ),
-    runbookSlug: z
-      .string()
-      .optional()
-      .describe(
-        "Config-as-Code only. Fetch a single CaC runbook by slug at the given gitRef. Requires gitRef.",
-      ),
-    gitRef: z
-      .string()
-      .optional()
-      .describe(
-        "For Config-as-Code projects only. A branch name (e.g. 'main'), tag, or commit SHA. Use get_branches to list available branches.",
-      ),
-    partialName: z
-      .string()
-      .optional()
-      .describe("Filter listing by partial runbook name (case-insensitive)."),
-    skip: z.number().optional().describe("Pagination offset."),
-    take: z.number().optional().describe("Pagination page size."),
-  })
-  .superRefine((args, ctx) => {
+// SDK workaround: publish a plain `z.object(...)` as `inputSchema`; refinements
+// live on `findRunbooksValidationSchema` and run inside the handler. See the
+// comment on run_runbook / find_events for the underlying reason.
+const findRunbooksRawShape = {
+  spaceName: z.string().describe("Space name."),
+  projectName: z
+    .string()
+    .describe(
+      "Project name. Runbooks are scoped to a project, so this is required for both single fetch and listing.",
+    ),
+  runbookId: z
+    .string()
+    .optional()
+    .describe(
+      "Fetch a single DB-backed runbook by ID (e.g. 'Runbooks-123'). Mutually exclusive with partialName/skip/take and with gitRef/runbookSlug.",
+    ),
+  runbookSlug: z
+    .string()
+    .optional()
+    .describe(
+      "Config-as-Code only. Fetch a single CaC runbook by slug at the given gitRef. Requires gitRef.",
+    ),
+  gitRef: z
+    .string()
+    .optional()
+    .describe(
+      "For Config-as-Code projects only. A branch name (e.g. 'main'), tag, or commit SHA. Use get_branches to list available branches.",
+    ),
+  partialName: z
+    .string()
+    .optional()
+    .describe("Filter listing by partial runbook name (case-insensitive)."),
+  skip: z.number().optional().describe("Pagination offset."),
+  take: z.number().optional().describe("Pagination page size."),
+};
+
+export const findRunbooksInputSchema = z.object(findRunbooksRawShape);
+
+export const findRunbooksValidationSchema = findRunbooksInputSchema.superRefine(
+  (args, ctx) => {
     if (args.runbookId && args.partialName) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -144,9 +151,10 @@ export const findRunbooksSchema = z
         path: ["runbookSlug"],
       });
     }
-  });
+  },
+);
 
-export type FindRunbooksParams = z.infer<typeof findRunbooksSchema>;
+export type FindRunbooksParams = z.infer<typeof findRunbooksValidationSchema>;
 
 export async function findRunbooksHandler(params: FindRunbooksParams) {
   const {
@@ -361,10 +369,14 @@ Modes:
 - neither               → list DB runbooks in the project (optionally filtered by partialName).
 
 Each summary includes multiTenancyMode and environmentScope so callers can determine which environments and tenants are valid targets before invoking run_runbook.`,
-      inputSchema: findRunbooksSchema,
+      inputSchema: findRunbooksInputSchema,
       annotations: READ_ONLY_TOOL_ANNOTATIONS,
     },
-    findRunbooksHandler,
+    async (args) => {
+      const parsed = findRunbooksValidationSchema.safeParse(args);
+      if (!parsed.success) return zodErrorResponse(parsed.error);
+      return findRunbooksHandler(parsed.data);
+    },
   );
 }
 

--- a/src/tools/runRunbook.ts
+++ b/src/tools/runRunbook.ts
@@ -15,82 +15,95 @@ import {
   unconfirmedResponse,
 } from "../helpers/requireConfirmation.js";
 import { hasRunbooksInGit } from "../helpers/vcsProjectHelpers.js";
+import { zodErrorResponse } from "../helpers/zodErrorResponse.js";
 
-export const runRunbookSchema = z
-  .object({
-    spaceName: z.string().describe("The space name"),
-    projectName: z.string().describe("The project name"),
-    runbookName: z
-      .string()
-      .describe("The runbook name (within the project)"),
-    environmentNames: z
-      .array(z.string())
-      .min(1)
-      .describe(
-        "Array of environment names. At least one environment must be provided.",
-      ),
-    tenants: z
-      .array(z.string())
-      .optional()
-      .describe("Array of tenant names for tenanted runs (optional)"),
-    tenantTags: z
-      .array(z.string())
-      .optional()
-      .describe(
-        "Array of tenant tags for tenanted runs (e.g., ['Region/US-West', 'Tier/Production'])",
-      ),
-    runbookSnapshotId: z
-      .string()
-      .optional()
-      .describe(
-        "DB-backed runbooks only. Specific snapshot ID. Defaults to the runbook's published snapshot if omitted. Not applicable to Config-as-Code runbooks.",
-      ),
-    gitRef: z
-      .string()
-      .optional()
-      .describe(
-        "Config-as-Code runbooks only. A branch name (e.g. 'main'), tag, or commit SHA. Use get_branches to list available refs. Mutually exclusive with runbookSnapshotId.",
-      ),
-    promptedVariableValues: z
-      .record(z.string())
-      .optional()
-      .describe("Prompted variable values as key-value pairs"),
-    useGuidedFailure: z
-      .boolean()
-      .optional()
-      .describe("Use guided failure mode"),
-    forcePackageDownload: z
-      .boolean()
-      .optional()
-      .describe("Force package download"),
-    specificMachineNames: z
-      .array(z.string())
-      .optional()
-      .describe("Run on specific machines only"),
-    excludedMachineNames: z
-      .array(z.string())
-      .optional()
-      .describe("Exclude specific machines from the run"),
-    skipStepNames: z
-      .array(z.string())
-      .optional()
-      .describe("Skip specific runbook steps"),
-    runAt: z
-      .string()
-      .optional()
-      .describe("Schedule run for later (ISO 8601 date string)"),
-    noRunAfter: z
-      .string()
-      .optional()
-      .describe("Don't run after this time (ISO 8601 date string)"),
-    confirm: z
-      .boolean()
-      .optional()
-      .describe(
-        "Required only when the MCP client does not support elicitation. Set to true to confirm the run; otherwise the tool aborts.",
-      ),
-  })
-  .superRefine((args, ctx) => {
+// SDK workaround: publish a plain `z.object(...)` as `inputSchema`.
+// `.superRefine(...)` produces a ZodEffects wrapper that lacks `.shape`, and
+// @modelcontextprotocol/sdk's `normalizeObjectSchema` does not unwrap
+// ZodEffects — the published inputSchema collapses to a single-field opaque
+// schema, so MCP clients see no field types and the LLM stringifies
+// arrays/booleans/numbers (e.g. `environmentNames: ["Test"]` arrives as the
+// string `'["Test"]'`). Cross-field invariants live on
+// `runRunbookValidationSchema` below and run inside the handler via
+// `safeParse`. See find_events for the same pattern.
+const runRunbookRawShape = {
+  spaceName: z.string().describe("The space name"),
+  projectName: z.string().describe("The project name"),
+  runbookName: z
+    .string()
+    .describe("The runbook name (within the project)"),
+  environmentNames: z
+    .array(z.string())
+    .min(1)
+    .describe(
+      "Array of environment names. At least one environment must be provided.",
+    ),
+  tenants: z
+    .array(z.string())
+    .optional()
+    .describe("Array of tenant names for tenanted runs (optional)"),
+  tenantTags: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Array of tenant tags for tenanted runs (e.g., ['Region/US-West', 'Tier/Production'])",
+    ),
+  runbookSnapshotId: z
+    .string()
+    .optional()
+    .describe(
+      "DB-backed runbooks only. Specific snapshot ID. Defaults to the runbook's published snapshot if omitted. Not applicable to Config-as-Code runbooks.",
+    ),
+  gitRef: z
+    .string()
+    .optional()
+    .describe(
+      "Config-as-Code runbooks only. A branch name (e.g. 'main'), tag, or commit SHA. Use get_branches to list available refs. Mutually exclusive with runbookSnapshotId.",
+    ),
+  promptedVariableValues: z
+    .record(z.string())
+    .optional()
+    .describe("Prompted variable values as key-value pairs"),
+  useGuidedFailure: z
+    .boolean()
+    .optional()
+    .describe("Use guided failure mode"),
+  forcePackageDownload: z
+    .boolean()
+    .optional()
+    .describe("Force package download"),
+  specificMachineNames: z
+    .array(z.string())
+    .optional()
+    .describe("Run on specific machines only"),
+  excludedMachineNames: z
+    .array(z.string())
+    .optional()
+    .describe("Exclude specific machines from the run"),
+  skipStepNames: z
+    .array(z.string())
+    .optional()
+    .describe("Skip specific runbook steps"),
+  runAt: z
+    .string()
+    .optional()
+    .describe("Schedule run for later (ISO 8601 date string)"),
+  noRunAfter: z
+    .string()
+    .optional()
+    .describe("Don't run after this time (ISO 8601 date string)"),
+  confirm: z
+    .boolean()
+    .optional()
+    .describe(
+      "Required only when the MCP client does not support elicitation. Set to true to confirm the run; otherwise the tool aborts.",
+    ),
+};
+
+export const runRunbookInputSchema = z.object(runRunbookRawShape);
+
+export const runRunbookValidationSchema = runRunbookInputSchema.superRefine(
+  (args, ctx) => {
     if (args.gitRef && args.runbookSnapshotId) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -99,9 +112,10 @@ export const runRunbookSchema = z
         path: ["runbookSnapshotId"],
       });
     }
-  });
+  },
+);
 
-export type RunRunbookParams = z.infer<typeof runRunbookSchema>;
+export type RunRunbookParams = z.infer<typeof runRunbookValidationSchema>;
 
 function defaultBranchOf(project: Project): string | undefined {
   if (project.PersistenceSettings.Type === "VersionControlled") {
@@ -346,10 +360,17 @@ Runbooks execute operational processes (DB backups, smoke tests, environment ref
 Two project kinds:
 - DB-backed projects: by default the runbook's published snapshot is used; pass runbookSnapshotId to pick a specific snapshot.
 - Config-as-Code projects: pass gitRef (branch name like 'main', tag, or commit SHA). Snapshots don't apply — the gitRef is the version pin. Use find_runbooks with the same gitRef to discover runbook names.`,
-      inputSchema: runRunbookSchema,
+      inputSchema: runRunbookInputSchema,
       annotations: DESTRUCTIVE_WRITE_TOOL_ANNOTATIONS,
     },
-    (params) => runRunbookHandler(server, params),
+    async (params) => {
+      // Cross-field validation. Lives here (not on `inputSchema`) because the
+      // refined version is a ZodEffects that the SDK collapses to an empty
+      // published schema — see the comment on `runRunbookRawShape`.
+      const parsed = runRunbookValidationSchema.safeParse(params);
+      if (!parsed.success) return zodErrorResponse(parsed.error);
+      return runRunbookHandler(server, parsed.data);
+    },
   );
 }
 

--- a/src/tools/updateFeatureToggle.ts
+++ b/src/tools/updateFeatureToggle.ts
@@ -9,6 +9,7 @@ import {
   requireConfirmation,
   unconfirmedResponse,
 } from "../helpers/requireConfirmation.js";
+import { zodErrorResponse } from "../helpers/zodErrorResponse.js";
 import {
   type FeatureToggleResource,
   type FeatureToggleEnvironmentResource,
@@ -40,39 +41,47 @@ const environmentPatchSchema = z.object({
     .describe("Client-side fractional rollout evaluated by the SDK [0, 100]."),
 });
 
-export const updateFeatureToggleSchema = z
-  .object({
-    spaceName: z.string().describe("Space name."),
-    projectId: z
-      .string()
-      .describe("Project ID (e.g. Projects-123). Feature toggles are scoped per project."),
-    slug: z
-      .string()
-      .describe("The toggle's Slug (not its Id). Find it via find_feature_toggles."),
-    defaultIsEnabled: z
-      .boolean()
-      .optional()
-      .describe(
-        "Toggle-level default. The value returned for environments that have no explicit per-environment configuration.",
-      ),
-    description: z
-      .string()
-      .optional()
-      .describe("Toggle-level description (max 1000 chars). Markdown supported in the UI."),
-    environments: z
-      .array(environmentPatchSchema)
-      .optional()
-      .describe(
-        "Per-environment patches. Environments not listed here are preserved as-is. Each entry must reference a deploymentEnvironmentId that already exists on the toggle; unknown environments are rejected rather than silently added. Each environment may appear at most once in this array — duplicates are rejected.",
-      ),
-    confirm: z
-      .boolean()
-      .optional()
-      .describe(
-        "Required only when the MCP client does not support elicitation. Set to true to confirm the update; otherwise the tool aborts.",
-      ),
-  })
-  .superRefine((args, ctx) => {
+// SDK workaround: publish a plain `z.object(...)` as `inputSchema`; refinements
+// live on `updateFeatureToggleValidationSchema` and run inside the handler.
+// See the comment on run_runbook / find_events for the underlying reason.
+const updateFeatureToggleRawShape = {
+  spaceName: z.string().describe("Space name."),
+  projectId: z
+    .string()
+    .describe("Project ID (e.g. Projects-123). Feature toggles are scoped per project."),
+  slug: z
+    .string()
+    .describe("The toggle's Slug (not its Id). Find it via find_feature_toggles."),
+  defaultIsEnabled: z
+    .boolean()
+    .optional()
+    .describe(
+      "Toggle-level default. The value returned for environments that have no explicit per-environment configuration.",
+    ),
+  description: z
+    .string()
+    .optional()
+    .describe("Toggle-level description (max 1000 chars). Markdown supported in the UI."),
+  environments: z
+    .array(environmentPatchSchema)
+    .optional()
+    .describe(
+      "Per-environment patches. Environments not listed here are preserved as-is. Each entry must reference a deploymentEnvironmentId that already exists on the toggle; unknown environments are rejected rather than silently added. Each environment may appear at most once in this array — duplicates are rejected.",
+    ),
+  confirm: z
+    .boolean()
+    .optional()
+    .describe(
+      "Required only when the MCP client does not support elicitation. Set to true to confirm the update; otherwise the tool aborts.",
+    ),
+};
+
+export const updateFeatureToggleInputSchema = z.object(
+  updateFeatureToggleRawShape,
+);
+
+export const updateFeatureToggleValidationSchema =
+  updateFeatureToggleInputSchema.superRefine((args, ctx) => {
     // Reject duplicate deploymentEnvironmentIds up front. Without this,
     // the merge picks the FIRST patch for the env while the confirmation
     // diff overwrites earlier entries with later ones using the same key —
@@ -96,7 +105,9 @@ export const updateFeatureToggleSchema = z
     }
   });
 
-export type UpdateFeatureToggleParams = z.infer<typeof updateFeatureToggleSchema>;
+export type UpdateFeatureToggleParams = z.infer<
+  typeof updateFeatureToggleValidationSchema
+>;
 
 interface PatchedEnvironment {
   current: FeatureToggleEnvironmentResource;
@@ -390,10 +401,14 @@ Narrow surface — flip an environment on/off, change rollout percentages, or up
 Deliberately not exposed: name/slug rename, tag changes, rollout group attach/detach, tenant targeting, segments, minimum version, adding or removing environment configurations entirely. For those, use the Octopus UI.
 
 Patches that reference an environment not already configured on the toggle are rejected with reason: environment_not_configured. The tool does not add new environment configurations.`,
-      inputSchema: updateFeatureToggleSchema,
+      inputSchema: updateFeatureToggleInputSchema,
       annotations: DESTRUCTIVE_WRITE_TOOL_ANNOTATIONS,
     },
-    (args) => updateFeatureToggleHandler(server, args),
+    async (args) => {
+      const parsed = updateFeatureToggleValidationSchema.safeParse(args);
+      if (!parsed.success) return zodErrorResponse(parsed.error);
+      return updateFeatureToggleHandler(server, parsed.data);
+    },
   );
 }
 


### PR DESCRIPTION
NB: I have not reviewed this PR, it's all Claude.

## Background

I could not get Claude to deploy a runbook using the MCP server

```
 MCP error -32602: Input validation error: Invalid arguments for tool run_runbook: [
    {
      "code": "invalid_type",
      "expected": "array",
      "received": "string",
      "path": ["environmentNames"],
      "message": "Expected array, received string"
    }
  ]
```

Claude was sending:

```
  mcp__octopus-deploy__run_runbook
    spaceName: "Default"
    projectName: "MyProject"
    runbookName: "Run E2E Tests"
    gitRef: "dc073e56b32e9d01c3c5de70bc3ba80e1de87855"
    environmentNames: ["Test"]
```

## Summary

- `run_runbook`, `find_runbooks`, `find_releases`, `find_interruptions`, and `update_feature_toggle` were registering `z.object(...).superRefine(...)` as their MCP `inputSchema`. `superRefine` produces a `ZodEffects` wrapper that hides `.shape`, which the SDK's `normalizeObjectSchema` walks to build the published schema — so the schema collapsed to a single opaque field and clients stringified arrays, booleans, and numbers (e.g. `environmentNames: ["Test"]` arrived as the string `'["Test"]'`, failing the inner `z.array(z.string())` validator).
- Applied the workaround already used by `find_events`: publish a plain `z.object(...)` as `inputSchema`, keep cross-field invariants on a separate `…ValidationSchema`, and run `safeParse` inside the handler.
- Extracted `zodErrorResponse` to `src/helpers/zodErrorResponse.ts` so all affected tools (including `find_events`) share one implementation.
- Added a regression test in `runRunbook.handler.test.ts` asserting `environmentNames: ["Test"]` is accepted, plus SDK-workaround guard tests mirroring `findEvents.test.ts`.
