### PR TITLE
fix: bump axios and add npm audit signatures to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,9 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        # Node 24 bundles npm >= 11.12, which honors the `min-release-age`
+        # setting in .npmrc. Node 22 ships npm 10.9 and would silently ignore it.
+        node-version: [24.x]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,12 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
+    # Verify every installed package has a valid registry signature before any
+    # of its code is allowed to run (lint, build, test). Catches tarball swaps
+    # like the TanStack Mini Shai-Hulud compromise on the consumer side.
+    - name: Verify dependency signatures
+      run: npm audit signatures
+
     - name: Run linting
       run: npm run lint
       continue-on-error: true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,8 @@
+# Refuse to resolve package versions published less than 3 days ago. Mitigates
+# supply-chain attacks like TanStack "Mini Shai-Hulud" by giving researchers
+# time to detect and report malicious uploads before we pick them up. Applies
+# to `npm install` / `npm update` (lockfile changes); `npm ci` is unaffected
+# because it installs the already-pinned lockfile as-is.
+#
+# Requires npm >= 11.10.0. Silently ignored on older npm.
+min-release-age=3

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",
         "@octopusdeploy/api-client": "^3.8.0",
-        "axios": "^1.12.2",
+        "axios": "^1.15.2",
         "commander": "^14.0.0",
         "dotenv": "^17.2.2",
         "zod": "^3.25.76"
@@ -1808,6 +1808,18 @@
         "node": ">=12.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -1930,13 +1942,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -2804,12 +2817,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2859,9 +2872,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -3246,9 +3259,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3279,6 +3292,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/iconv-lite": {
@@ -3369,9 +3395,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4142,9 +4168,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.5",
     "@octopusdeploy/api-client": "^3.8.0",
-    "axios": "^1.12.2",
+    "axios": "^1.15.2",
     "commander": "^14.0.0",
     "dotenv": "^17.2.2",
     "zod": "^3.25.76"


### PR DESCRIPTION
## Summary

- **Bumps `axios` `^1.12.2` → `^1.15.2`** to fix two HIGH prototype-pollution CVEs ([GHSA-q8qp-cvcw-x6jj](https://github.com/advisories/GHSA-q8qp-cvcw-x6jj), [GHSA-3w6x-2g7m-8v23](https://github.com/advisories/GHSA-3w6x-2g7m-8v23)). Axios is used directly and re-used by `@octopusdeploy/api-client`, so this is on the real attack surface — every Octopus HTTP response is parsed by the vulnerable code.
- **`npm audit fix`** resolves the five remaining transitive advisories (`fast-uri`, `hono`, `ip-address`, `express-rate-limit`, `postcss`) within existing semver ranges. No `overrides` needed. `npm audit` reports **0 vulnerabilities** after this change (was 6).
- **Adds `npm audit signatures` step** to `.github/workflows/build.yml`, gated after `npm ci` and before lint/build. Verifies every installed package has a valid npm-registry signature before any of its code is allowed to run in CI. Consumer-side guardrail against tarball-swap attacks like the recent TanStack "Mini Shai-Hulud" compromise.
- **Adds `.npmrc` with `min-release-age=3`** — npm refuses to resolve package versions published in the last 3 days. The TanStack compromise was publicly detected 26 minutes after upload; a 3-day cooldown gives researchers and automated scanners time to flag malicious tarballs before we pull them into the lockfile. Applies to `npm install` / `npm update` (resolution), not `npm ci` (which is already lockfile-pinned).
- **Bumps `build.yml` Node version 22 → 24** so npm 11.12 (which honors `min-release-age`) is in use. Node 22 bundles npm 10.9 and would silently ignore the setting. `publish.yml` and the Dockerfile already use Node 24.

The repo was not exposed to the TanStack compromise (no `@tanstack/*`, `@uipath/*`, `@mistralai/*`, `@squawk/*` deps anywhere in the tree), but this PR closes the unrelated CVEs surfaced by audit and adds two defensive measures.

## Test plan

- [x] `npm audit` clean (0 vulnerabilities, was 6)
- [x] `npm audit signatures` clean locally (341/341 verified, 57 with provenance)
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] Unit tests pass (247/247). Integration tests require live Octopus credentials and are unrelated to this change.
- [ ] CI passes on Node 24 with the new `Verify dependency signatures` step

## Contributor note

Developers using npm < 11.10 will silently ignore the new `min-release-age` setting locally. To enforce it in your dev environment, run `npm install -g npm@latest` (or use a Node 24+ install via `nvm`/`fnm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)