### PR TITLE
fix: skip elicitations when clients lie about their capabilities

### DIFF
--- a/src/helpers/__tests__/requireConfirmation.test.ts
+++ b/src/helpers/__tests__/requireConfirmation.test.ts
@@ -222,13 +222,27 @@ describe("requireConfirmation", () => {
       expect(call.message).toBe("Plain prompt?");
     });
 
-    it("ignores fallbackConfirm when elicitation is used", async () => {
-      stub.elicitInput.mockResolvedValue({ action: "decline" });
+    it("honours fallbackConfirm: true before attempting elicitation", async () => {
+      // Some clients advertise elicitation capability but cannot actually render
+      // a usable prompt (or auto-decline). When the LLM explicitly passes
+      // `confirm: true` it's asserting the user approved out-of-band, so we
+      // must short-circuit before sending a doomed elicitation request.
       const result = await requireConfirmation(makeServer(stub), {
         message: "x",
         fallbackConfirm: true,
       });
-      expect(result).toEqual({ confirmed: false, reason: "declined" });
+      expect(result).toEqual({ confirmed: true, reason: "fallbackConfirm" });
+      expect(stub.elicitInput).not.toHaveBeenCalled();
+    });
+
+    it("falls through to elicitation when fallbackConfirm is false", async () => {
+      stub.elicitInput.mockResolvedValue({ action: "accept" });
+      const result = await requireConfirmation(makeServer(stub), {
+        message: "x",
+        fallbackConfirm: false,
+      });
+      expect(result).toEqual({ confirmed: true, reason: "accepted" });
+      expect(stub.elicitInput).toHaveBeenCalledOnce();
     });
 
     it("propagates errors from elicitInput", async () => {

--- a/src/helpers/requireConfirmation.ts
+++ b/src/helpers/requireConfirmation.ts
@@ -141,12 +141,18 @@ export type ConfirmationResult =
  *
  * Resolution order:
  *   1. `OCTOPUS_SKIP_ELICITATION=true` env var → bypass (automation/CI).
- *   2. Client advertises elicitation capability → SDK emits `elicitation/create`
+ *   2. Explicit `fallbackConfirm: true` from the caller → accepted. The LLM is
+ *      asserting the user approved out-of-band; trust it whether or not the
+ *      client also advertises elicitation. Some clients advertise the
+ *      capability but cannot actually render a usable prompt, which previously
+ *      meant `confirm: true` could never take effect on those clients despite
+ *      the tool's input schema saying it should.
+ *   3. Client advertises elicitation capability → SDK emits `elicitation/create`
  *      and we map `result.action` to accepted/declined/cancelled.
- *   3. Client does not advertise elicitation → fall back to the `confirm` arg
- *      the tool surfaced in its own input schema. Distinguishes between
- *      explicit `false` (declined) and missing (confirmationRequired) so the
- *      caller can surface the latter as a hard error.
+ *   4. Client does not advertise elicitation → fall back to the explicit
+ *      `false` / missing values of `confirm`. Distinguishes between explicit
+ *      `false` (declined) and missing (confirmationRequired) so the caller
+ *      can surface the latter as a hard error.
  */
 export async function requireConfirmation(
   server: McpServer,
@@ -154,6 +160,10 @@ export async function requireConfirmation(
 ): Promise<ConfirmationResult> {
   if (env["OCTOPUS_SKIP_ELICITATION"] === "true") {
     return { confirmed: true, reason: "envSkip" };
+  }
+
+  if (opts.fallbackConfirm === true) {
+    return { confirmed: true, reason: "fallbackConfirm" };
   }
 
   const capabilities = server.server.getClientCapabilities();
@@ -175,9 +185,6 @@ export async function requireConfirmation(
     }
   }
 
-  if (opts.fallbackConfirm === true) {
-    return { confirmed: true, reason: "fallbackConfirm" };
-  }
   if (opts.fallbackConfirm === false) {
     return { confirmed: false, reason: "declined" };
   }


### PR DESCRIPTION
## Problem

Some MCP clients, like Claude Code, advertise that they support elicitations but it depends on where it is running. Claude Code in the CLI seems to support them just fine and asks the user for confirmations, while Claude Code in the desktop app just skips rendering confirmations all together. This creates an issue where since the client is advertising elicitations capability we are not allowing `confirm: true` to skip them but that completely blocks user from doing any write actions.

## Solution

This PR basically reverses the behavior: if `confirm: true` is set then we skip elicitations even if they are "supported". Unfortunate, but unblocks customers using clients that don't correctly say what they actually support.