### PR TITLE
fix: require @modelcontextprotocol/sdk >=1.22.0 so tools/list works

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,15 @@ Each tool file exports a registration that includes:
 
 #### MCP SDK: use `registerTool`, not `tool`
 
+> **Minimum SDK is `^1.22.0` — do not lower it.** Six tools (`find_releases`, `find_runbooks`,
+> `find_interruptions`, `find_events`, `update_feature_toggle`, `run_runbook`) pass a full
+> `z.object(...)` as `inputSchema` rather than a raw shape. SDK releases before 1.22.0 mistake that
+> ZodObject instance for a raw shape and re-wrap it with `z.object(...)`, dragging the instance's own
+> internals — including the `_cached: null` field every zod v3 ZodObject carries — into the shape.
+> JSON Schema conversion then dies on `null._def` and **`tools/list` fails outright** with
+> `-32603 Cannot read properties of null (reading '_def')`, taking every tool down with it.
+> `src/tools/__tests__/toolsList.test.ts` guards both the floor and the published schemas.
+
 `server.tool(...)` is **deprecated** in `@modelcontextprotocol/sdk` and only accepts a `ZodRawShapeCompat` (a flat object of zod schemas) as its input schema. Refined schemas (`z.object(...).superRefine(...)`, `z.discriminatedUnion(...)`, etc.) cannot be used with `tool()` — TypeScript will reject the assignment.
 
 New tools must use `server.registerTool(name, config, handler)`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.17.5",
+        "@modelcontextprotocol/sdk": "^1.22.0",
         "@octopusdeploy/api-client": "^3.11.3",
         "axios": "^1.15.2",
         "commander": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.5",
+    "@modelcontextprotocol/sdk": "^1.22.0",
     "@octopusdeploy/api-client": "^3.11.3",
     "axios": "^1.15.2",
     "commander": "^14.0.0",

--- a/src/tools/__tests__/toolsList.test.ts
+++ b/src/tools/__tests__/toolsList.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createRequire } from "node:module";
+
+import { registerTools } from "../index.js";
+import { TOOL_REGISTRY } from "../../types/toolConfig.js";
+
+/**
+ * `tools/list` is the first call every MCP client makes after `initialize`. If
+ * it throws, the whole server is dead on arrival — no tool is reachable, and
+ * the client only sees an opaque `-32603`.
+ *
+ * It regressed exactly that way once: six tools publish a full `z.object(...)`
+ * as their `inputSchema` (see the "SDK workaround" comments on find_releases,
+ * find_runbooks, find_interruptions, find_events, update_feature_toggle and
+ * run_runbook), and @modelcontextprotocol/sdk below 1.22.0 mistook that
+ * ZodObject instance for a raw shape. It re-wrapped it with `z.object(...)`,
+ * pulling the instance's own internals — including the `_cached: null` field
+ * every v3 ZodObject carries — into the shape, and the JSON Schema conversion
+ * then died on `null._def`.
+ */
+describe("tools/list — end-to-end over a real MCP transport", () => {
+  async function listTools() {
+    const server = new McpServer({ name: "test", version: "0.0.0" });
+    registerTools(server, { enabledToolsets: "all" });
+
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+
+    try {
+      return (await client.listTools()).tools;
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  }
+
+  it("returns every registered tool without throwing", async () => {
+    const tools = await listTools();
+    expect(tools).toHaveLength(TOOL_REGISTRY.size);
+  });
+
+  it("publishes a usable object schema for every tool", async () => {
+    const tools = await listTools();
+
+    for (const tool of tools) {
+      expect(tool.inputSchema, `${tool.name} has no inputSchema`).toBeDefined();
+      expect(tool.inputSchema.type, `${tool.name} is not an object schema`).toBe(
+        "object",
+      );
+    }
+  });
+
+  it("does not leak Zod instance internals into any published schema", async () => {
+    const tools = await listTools();
+
+    // `_cached`, `_def`, `spa` and friends only appear as schema properties
+    // when a ZodObject instance was mistakenly spread as a raw shape.
+    for (const tool of tools) {
+      const properties = Object.keys(tool.inputSchema.properties ?? {});
+      const internals = properties.filter((key) => key.startsWith("_"));
+      expect(internals, `${tool.name} leaked Zod internals`).toEqual([]);
+    }
+  });
+
+  it("keeps the declared fields of tools that publish a full ZodObject", async () => {
+    const tools = await listTools();
+    const byName = new Map(tools.map((tool) => [tool.name, tool]));
+
+    // These are the six tools that pass a ZodObject rather than a raw shape.
+    // A collapse to `{}` here means clients lose all field types and the LLM
+    // starts stringifying arrays, booleans and numbers.
+    const expectedFields: Record<string, string[]> = {
+      find_releases: ["spaceName", "releaseId", "projectId", "searchByVersion"],
+      find_runbooks: ["spaceName"],
+      find_interruptions: ["spaceName"],
+      find_events: ["spaceName", "regarding", "eventCategories"],
+      update_feature_toggle: ["spaceName", "projectId"],
+      run_runbook: ["spaceName", "projectName", "runbookName", "environmentNames"],
+    };
+
+    for (const [name, fields] of Object.entries(expectedFields)) {
+      const tool = byName.get(name);
+      expect(tool, `${name} was not registered`).toBeDefined();
+      const properties = Object.keys(tool!.inputSchema.properties ?? {});
+      for (const field of fields) {
+        expect(properties, `${name} is missing ${field}`).toContain(field);
+      }
+    }
+  });
+});
+
+describe("@modelcontextprotocol/sdk version floor", () => {
+  it("requires at least 1.22.0, the first release that accepts a ZodObject inputSchema", () => {
+    const require = createRequire(import.meta.url);
+    const { dependencies } = require("../../../package.json") as {
+      dependencies: Record<string, string>;
+    };
+
+    const range = dependencies["@modelcontextprotocol/sdk"];
+    const floor = range.replace(/^[^\d]*/, "");
+    const [major, minor] = floor.split(".").map(Number);
+
+    // Below 1.22.0 the server cannot answer tools/list at all — see the
+    // comment on the suite above. The caret range must not reach back into
+    // those releases.
+    expect(major).toBe(1);
+    expect(minor).toBeGreaterThanOrEqual(22);
+  });
+});


### PR DESCRIPTION
## The bug

`initialize` succeeds, then `tools/list` fails outright:

```
-32603  Cannot read properties of null (reading '_def')
```

Every tool is unreachable — the server is dead on arrival.

## Root cause

Not the schema construction itself. It's the dependency range.

Six tools pass a full `z.object(...)` as their `inputSchema` rather than a raw shape (the "SDK workaround" tools: `find_releases`, `find_runbooks`, `find_interruptions`, `find_events`, `update_feature_toggle`, `run_runbook`). SDK releases **before 1.22.0** mistake that ZodObject *instance* for a raw shape and re-wrap it with `z.object(...)`, dragging the instance's own internals into the shape — including the `_cached: null` field every zod v3 ZodObject carries. JSON Schema conversion then dies on `null._def`.

Isolated per-tool against the published 2.3.1 tarball:

```
find_releases          zod:ZodObject   THROWS: Cannot read properties of null (reading '_def')
find_runbooks          zod:ZodObject   THROWS: ...
find_interruptions     zod:ZodObject   THROWS: ...
find_events            zod:ZodObject   THROWS: ...
update_feature_toggle  zod:ZodObject   THROWS: ...
run_runbook            zod:ZodObject   THROWS: ...

NULL FIELD: tool=find_releases field=_cached value=null
```

We declared `^1.17.5`, which admits six broken releases. Bisected:

| SDK | `tools/list` |
|---|---|
| 1.17.5 / 1.19.1 / 1.21.0 / 1.21.1 / 1.21.2 | ❌ `-32603 … reading '_def'` |
| 1.22.0 → 1.30.0 | ✅ 30 tools |

A fresh install today resolves 1.30.0 and works, which is why this reads as intermittent. It bites whenever a consumer's tree resolves an older SDK — a `min-release-age`/cooldown config, an offline cache, or another dependent pinning the SDK.

## The fix

- `package.json` — floor raised to `^1.22.0`, excluding every broken release. Lockfile refreshed (resolves 1.26.0).
- `src/tools/__tests__/toolsList.test.ts` (new) — four tests drive a real `tools/list` over `InMemoryTransport` (all tools returned, every schema an object, no `_`-prefixed Zod internals leaked, declared fields preserved for the six ZodObject tools); a fifth asserts the floor stays ≥ 1.22.0. That one fails before this change (`expected 17 to be greater than or equal to 22`).
- `CLAUDE.md` — documents why the floor exists, so it doesn't get lowered back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
